### PR TITLE
Return TBA IAB Provider 

### DIFF
--- a/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
+++ b/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
@@ -15,6 +15,7 @@ import { checkCrossOriginOpenerPolicy } from ':util/checkCrossOriginOpenerPolicy
 import { validatePreferences, validateSubAccount } from ':util/validatePreferences.js';
 import { decodeAbiParameters, encodeFunctionData, toHex } from 'viem';
 import { BaseAccountProvider } from './BaseAccountProvider.js';
+import { getInjectedProvider } from './getInjectedProvider.js';
 
 export type CreateProviderOptions = Partial<AppMetadata> & {
   preference?: Preference;
@@ -81,7 +82,7 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
   const sdk = {
     getProvider: () => {
       if (!provider) {
-        provider = new BaseAccountProvider(options);
+        provider = getInjectedProvider() ?? new BaseAccountProvider(options);
       }
 
       return provider;

--- a/packages/account-sdk/src/interface/builder/core/getInjectedProvider.test.ts
+++ b/packages/account-sdk/src/interface/builder/core/getInjectedProvider.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getInjectedProvider } from './getInjectedProvider.js';
+
+// Mock the global window object
+const mockWindow = {
+  ethereum: undefined as any,
+  top: {
+    ethereum: undefined as any,
+  },
+};
+
+// Store the original window object
+const originalWindow = global.window;
+
+describe('getInjectedProvider', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.clearAllMocks();
+
+    // Reset the mock window state
+    mockWindow.ethereum = undefined;
+    mockWindow.top.ethereum = undefined;
+
+    // Set up the global window mock
+    global.window = mockWindow as any;
+  });
+
+  afterEach(() => {
+    // Restore original window
+    global.window = originalWindow;
+  });
+
+  describe('when window.ethereum exists', () => {
+    it('should return the provider when it has the TBA identifier', () => {
+      const mockProvider = {
+        isCoinbaseBrowser: true,
+        request: vi.fn(),
+      };
+      mockWindow.ethereum = mockProvider;
+
+      const result = getInjectedProvider();
+
+      expect(result).toBe(mockProvider);
+    });
+
+    it('should return null when provider does not have the TBA identifier', () => {
+      const mockProvider = {
+        request: vi.fn(),
+      };
+      mockWindow.ethereum = mockProvider;
+
+      const result = getInjectedProvider();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when TBA identifier is false', () => {
+      const mockProvider = {
+        isCoinbaseBrowser: false,
+        request: vi.fn(),
+      };
+      mockWindow.ethereum = mockProvider;
+
+      const result = getInjectedProvider();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('when window.ethereum does not exist', () => {
+    it('should return window.top.ethereum when it has the TBA identifier', () => {
+      const mockProvider = {
+        isCoinbaseBrowser: true,
+        request: vi.fn(),
+      };
+      mockWindow.ethereum = undefined;
+      mockWindow.top.ethereum = mockProvider;
+
+      const result = getInjectedProvider();
+
+      expect(result).toBe(mockProvider);
+    });
+
+    it('should return null when window.top.ethereum does not have the TBA identifier', () => {
+      const mockProvider = {
+        request: vi.fn(),
+      };
+      mockWindow.ethereum = undefined;
+      mockWindow.top.ethereum = mockProvider;
+
+      const result = getInjectedProvider();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when window.top.ethereum does not exist', () => {
+      mockWindow.ethereum = undefined;
+      mockWindow.top.ethereum = undefined;
+
+      const result = getInjectedProvider();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('when both window.ethereum and window.top.ethereum exist', () => {
+    it('should prefer window.ethereum over window.top.ethereum', () => {
+      const windowProvider = {
+        isCoinbaseBrowser: true,
+        request: vi.fn(),
+        source: 'window',
+      };
+      const topProvider = {
+        isCoinbaseBrowser: true,
+        request: vi.fn(),
+        source: 'top',
+      };
+
+      mockWindow.ethereum = windowProvider;
+      mockWindow.top.ethereum = topProvider;
+
+      const result = getInjectedProvider();
+
+      expect(result).toBe(windowProvider);
+      expect(result).not.toBe(topProvider);
+    });
+
+    it('should return null when window.ethereum exists but lacks TBA identifier (does not fallback)', () => {
+      const windowProvider = {
+        request: vi.fn(),
+        source: 'window',
+      };
+      const topProvider = {
+        isCoinbaseBrowser: true,
+        request: vi.fn(),
+        source: 'top',
+      };
+
+      mockWindow.ethereum = windowProvider;
+      mockWindow.top.ethereum = topProvider;
+
+      const result = getInjectedProvider();
+
+      expect(result).toBeNull();
+    });
+
+    it('should fallback to window.top.ethereum when window.ethereum is null', () => {
+      const topProvider = {
+        isCoinbaseBrowser: true,
+        request: vi.fn(),
+        source: 'top',
+      };
+
+      mockWindow.ethereum = null;
+      mockWindow.top.ethereum = topProvider;
+
+      const result = getInjectedProvider();
+
+      expect(result).toBe(topProvider);
+    });
+
+    it('should return null when neither has TBA identifier', () => {
+      const windowProvider = {
+        request: vi.fn(),
+        source: 'window',
+      };
+      const topProvider = {
+        request: vi.fn(),
+        source: 'top',
+      };
+
+      mockWindow.ethereum = windowProvider;
+      mockWindow.top.ethereum = topProvider;
+
+      const result = getInjectedProvider();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle null window.ethereum', () => {
+      mockWindow.ethereum = null;
+      mockWindow.top.ethereum = undefined;
+
+      const result = getInjectedProvider();
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle missing window.top', () => {
+      mockWindow.ethereum = undefined;
+      (mockWindow as any).top = undefined;
+
+      const result = getInjectedProvider();
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/account-sdk/src/interface/builder/core/getInjectedProvider.ts
+++ b/packages/account-sdk/src/interface/builder/core/getInjectedProvider.ts
@@ -1,0 +1,23 @@
+import { ProviderInterface } from ':core/provider/interface.js';
+
+declare global {
+  interface Window {
+    ethereum?: InjectedProvider;
+  }
+}
+
+const TBA_PROVIDER_IDENTIFIER = 'isCoinbaseBrowser';
+
+type InjectedProvider = ProviderInterface & {
+  [TBA_PROVIDER_IDENTIFIER]?: boolean;
+};
+
+export function getInjectedProvider(): InjectedProvider | null {
+  const injectedProvider = window.ethereum ?? window.top?.ethereum;
+
+  if (injectedProvider?.[TBA_PROVIDER_IDENTIFIER]) {
+    return injectedProvider;
+  }
+
+  return null;
+}


### PR DESCRIPTION
### _Summary_

We thought we got rid of injected provider. But turns out, TBA still injects IAB provider with a `isCoinbaseBrowser` flag. This PR is to revive this phantom of the palace.

### _How did you test your changes?_

Will test in TBA prod after merge
