### PR TITLE
pointer-events override + {app} bug

### DIFF
--- a/packages/account-sdk/src/ui/Dialog/Dialog.scss
+++ b/packages/account-sdk/src/ui/Dialog/Dialog.scss
@@ -1,6 +1,7 @@
 
 .-base-acc-sdk-css-reset {
   -webkit-font-smoothing: antialiased;
+  pointer-events: auto !important; // important to override the parent pointer-events: none;
   
   .-base-acc-sdk-dialog-container {
     position: fixed;

--- a/packages/account-sdk/src/util/web.test.ts
+++ b/packages/account-sdk/src/util/web.test.ts
@@ -24,6 +24,14 @@ vi.mock(':ui/Dialog/index.js', () => ({
 
 const mockOrigin = 'http://localhost';
 
+vi.mock(':store/store.js', () => ({
+  store: {
+    config: {
+      get: vi.fn().mockReturnValue({ metadata: { appName: 'Test App' } }),
+    },
+  },
+}));
+
 describe('PopupManager', () => {
   beforeAll(() => {
     global.window = Object.create(window);
@@ -87,7 +95,7 @@ describe('PopupManager', () => {
     await waitFor(() => {
       expect(mockPresentItem).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: expect.stringContaining('wants to continue in Base Account'),
+          title: 'Test App wants to continue in Base Account',
           message: 'This action requires your permission to open a new window.',
           actionItems: expect.arrayContaining([
             expect.objectContaining({
@@ -117,7 +125,7 @@ describe('PopupManager', () => {
     await waitFor(() => {
       expect(mockPresentItem).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: expect.stringContaining('wants to continue in Base Account'),
+          title: 'Test App wants to continue in Base Account',
           message: 'This action requires your permission to open a new window.',
           actionItems: expect.arrayContaining([
             expect.objectContaining({

--- a/packages/account-sdk/src/util/web.ts
+++ b/packages/account-sdk/src/util/web.ts
@@ -70,8 +70,8 @@ function openPopupWithDialog(tryOpenPopup: () => Window | null) {
   return new Promise<Window>((resolve, reject) => {
     logDialogShown({ dialogContext: 'popup_blocked' });
     dialog.presentItem({
-      title: POPUP_BLOCKED_TITLE,
-      message: POPUP_BLOCKED_MESSAGE.replace('{app}', dappName),
+      title: POPUP_BLOCKED_TITLE.replace('{app}', dappName),
+      message: POPUP_BLOCKED_MESSAGE,
       onClose: () => {
         logDialogActionClicked({
           dialogContext: 'popup_blocked',


### PR DESCRIPTION
### _Summary_

* overriding the pointer-event to auto, some UI lib have their body tag set to be opaque
* fix the `{app}` in some dialog title


### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
