### PR TITLE
fix: remove erroneous sub account presence check

### DIFF
--- a/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
+++ b/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
@@ -88,16 +88,13 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
       return provider;
     },
     subAccount: {
-      async create(account: AddSubAccountAccount): Promise<SubAccount> {
-        const state = store.getState();
-        assertPresence(state.subAccount?.address, new Error('subaccount already exists'));
-
+      async create(accountParam: AddSubAccountAccount): Promise<SubAccount> {
         return (await sdk.getProvider()?.request({
           method: 'wallet_addSubAccount',
           params: [
             {
               version: '1',
-              account,
+              account: accountParam,
             },
           ],
         })) as SubAccount;


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
Removed incorrect presence check in sub account create convenience method – the request handler will return a cached sub account if available.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

Manual testing, existing unit tests passing
