### PR TITLE
Normalize address validation

### DIFF
--- a/packages/account-sdk/src/interface/payment/pay.ts
+++ b/packages/account-sdk/src/interface/payment/pay.ts
@@ -7,7 +7,7 @@ import type { Address } from 'viem';
 import type { PaymentOptions, PaymentResult } from './types.js';
 import { executePaymentWithSDK } from './utils/sdkManager.js';
 import { translatePaymentToSendCalls } from './utils/translatePayment.js';
-import { validateAddress, validateStringAmount } from './utils/validation.js';
+import { normalizeAddress, validateStringAmount } from './utils/validation.js';
 
 /**
  * Pay a specified address with USDC on Base network using an ephemeral wallet
@@ -47,10 +47,15 @@ export async function pay(options: PaymentOptions): Promise<PaymentResult> {
 
   try {
     validateStringAmount(amount, 2);
-    validateAddress(to);
+    const normalizedAddress = normalizeAddress(to);
 
     // Step 2: Translate payment to sendCalls format
-    const requestParams = translatePaymentToSendCalls(to, amount, testnet, payerInfo);
+    const requestParams = translatePaymentToSendCalls(
+      normalizedAddress,
+      amount,
+      testnet,
+      payerInfo
+    );
 
     // Step 3: Execute payment with SDK
     const executionResult = await executePaymentWithSDK(
@@ -70,7 +75,7 @@ export async function pay(options: PaymentOptions): Promise<PaymentResult> {
       success: true,
       id: executionResult.transactionHash,
       amount: amount,
-      to: to as Address,
+      to: normalizedAddress,
       payerInfoResponses: executionResult.payerInfoResponses,
     };
   } catch (error) {

--- a/packages/account-sdk/src/interface/payment/utils/translatePayment.ts
+++ b/packages/account-sdk/src/interface/payment/utils/translatePayment.ts
@@ -8,14 +8,14 @@ import type { PayerInfo } from '../types.js';
  * @param amount - The amount in USDC (will be converted to 6 decimals)
  * @returns The encoded function data
  */
-export function encodeTransferCall(recipient: string, amount: string): Hex {
+export function encodeTransferCall(recipient: Address, amount: string): Hex {
   const amountInUnits = parseUnits(amount, TOKENS.USDC.decimals);
 
   // Encode the transfer function call
   return encodeFunctionData({
     abi: ERC20_TRANSFER_ABI,
     functionName: 'transfer',
-    args: [recipient as Address, amountInUnits],
+    args: [recipient, amountInUnits],
   });
 }
 
@@ -72,7 +72,7 @@ export function buildSendCallsRequest(transferData: Hex, testnet: boolean, payer
  * @returns The complete request parameters
  */
 export function translatePaymentToSendCalls(
-  recipient: string,
+  recipient: Address,
   amount: string,
   testnet: boolean,
   payerInfo?: PayerInfo

--- a/packages/account-sdk/src/interface/payment/utils/validation.test.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { validateStringAmount } from './validation.js';
+import { normalizeAddress, validateStringAmount } from './validation.js';
 
 describe('validateStringAmount', () => {
   it('should validate valid amounts', () => {
@@ -20,5 +20,47 @@ describe('validateStringAmount', () => {
 
   it('should reject non-string amounts', () => {
     expect(() => validateStringAmount(10 as any, 2)).toThrow('Invalid amount: must be a string');
+  });
+});
+
+describe('normalizeAddress', () => {
+  it('should throw error for empty address', () => {
+    expect(() => normalizeAddress('')).toThrow('Invalid address: address is required');
+  });
+
+  it('should throw error for invalid address', () => {
+    expect(() => normalizeAddress('not-an-address')).toThrow(
+      'Invalid address: must be a valid Ethereum address'
+    );
+    expect(() => normalizeAddress('0x123')).toThrow(
+      'Invalid address: must be a valid Ethereum address'
+    );
+  });
+
+  it('should accept and return checksummed address for valid checksummed address', () => {
+    const checksummedAddress = '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51';
+    const result = normalizeAddress(checksummedAddress);
+    expect(result).toBe(checksummedAddress);
+  });
+
+  it('should accept non-checksummed address and return checksummed version', () => {
+    const nonChecksummedAddress = '0xfe21034794a5a574b94fe4fdfd16e005f1c96e51';
+    const expectedChecksummed = '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51';
+    const result = normalizeAddress(nonChecksummedAddress);
+    expect(result).toBe(expectedChecksummed);
+  });
+
+  it('should accept all uppercase address and return checksummed version', () => {
+    const upperCaseAddress = '0xFE21034794A5A574B94FE4FDFD16E005F1C96E51';
+    const expectedChecksummed = '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51';
+    const result = normalizeAddress(upperCaseAddress);
+    expect(result).toBe(expectedChecksummed);
+  });
+
+  it('should accept mixed case non-checksummed address and return checksummed version', () => {
+    const mixedCaseAddress = '0xfE21034794a5A574b94fe4FDfD16E005f1C96e51';
+    const expectedChecksummed = '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51';
+    const result = normalizeAddress(mixedCaseAddress);
+    expect(result).toBe(expectedChecksummed);
   });
 });

--- a/packages/account-sdk/src/interface/payment/utils/validation.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.ts
@@ -1,4 +1,4 @@
-import { isAddress } from 'viem';
+import { type Address, getAddress } from 'viem';
 
 /**
  * Validates that the amount is a positive string with max decimal places
@@ -35,13 +35,18 @@ export function validateStringAmount(amount: string, maxDecimals: number): void 
  * Validates that the address is a valid Ethereum address
  * @param address - The address to validate
  * @throws Error if address is invalid
+ * @returns The checksummed address
  */
-export function validateAddress(address: string): void {
+export function normalizeAddress(address: string): Address {
   if (!address) {
     throw new Error('Invalid address: address is required');
   }
 
-  if (!isAddress(address)) {
+  try {
+    // getAddress will normalize the address to its checksummed version
+    // It will throw if the address is invalid
+    return getAddress(address);
+  } catch (_error) {
     throw new Error('Invalid address: must be a valid Ethereum address');
   }
 }


### PR DESCRIPTION
### _Summary_

improves address validation:


- Enhanced address validation to normalize addresses to their checksummed format
- Updated `validateAddress` to `normalizeAddress` which now returns the checksummed address instead of just validating

### _How did you test your changes?_

- Added unit tests to verify non-checksummed addresses are properly normalized
- Updated existing tests to use the new `normalizeAddress` function
- All existing payment flow tests continue to pass
- Test coverage includes:
  - Lowercase addresses
  - Uppercase addresses  
  - Mixed case addresses
  - Invalid address handling
