### PR TITLE
fix: remove hard coded chain ID when requesting sub account owner change

### DIFF
--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -720,6 +720,7 @@ export class Signer {
         ownerIndex = await handleAddSubAccountOwner({
           ownerAccount: ownerAccount.account,
           globalAccountRequest: this.sendRequestToPopup.bind(this),
+          chainId: this.chain.id,
         });
         logAddOwnerCompleted({ method: request.method, correlationId });
       } catch (error) {

--- a/packages/account-sdk/src/sign/base-account/utils/handleAddSubAccountOwner.ts
+++ b/packages/account-sdk/src/sign/base-account/utils/handleAddSubAccountOwner.ts
@@ -13,9 +13,11 @@ import { presentAddOwnerDialog } from './presentAddOwnerDialog.js';
 export async function handleAddSubAccountOwner({
   ownerAccount,
   globalAccountRequest,
+  chainId,
 }: {
   ownerAccount: OwnerAccount;
   globalAccountRequest: (request: RequestArguments) => Promise<unknown>;
+  chainId: number;
 }) {
   const account = store.account.get();
   const subAccount = store.subAccounts.get();
@@ -62,7 +64,7 @@ export async function handleAddSubAccountOwner({
       {
         version: '1',
         calls,
-        chainId: numberToHex(84532),
+        chainId: numberToHex(chainId),
         from: globalAccount,
       },
     ],


### PR DESCRIPTION
### _Summary_

chain ID was hard coded to base sepolia when auto requesting sub account owner changes. Removed the hard coding in favor of providing the chain id from signer state.
### _How did you test your changes?_

updated unit tests and tested manually in playground
