### PR TITLE
Throw errors in pay function instead of returning error results

### DIFF
--- a/packages/account-sdk/src/interface/payment/pay.ts
+++ b/packages/account-sdk/src/interface/payment/pay.ts
@@ -17,19 +17,20 @@ import { normalizeAddress, validateStringAmount } from './utils/validation.js';
  * @param options.testnet - Whether to use Base Sepolia testnet (default: false)
  * @param options.payerInfo - Optional payer information configuration for data callbacks
  * @returns Promise<PaymentResult> - Result of the payment transaction
+ * @throws Error if the payment fails
  *
  * @example
  * ```typescript
- * const payment = await pay({
- *   amount: "10.50",
- *   to: "0xFe21034794A5a574B94fE4fDfD16e005F1C96e51",
- *   testnet: true
- * });
+ * try {
+ *   const payment = await pay({
+ *     amount: "10.50",
+ *     to: "0xFe21034794A5a574B94fE4fDfD16e005F1C96e51",
+ *     testnet: true
+ *   });
  *
- * if (payment.success) {
  *   console.log(`Payment sent! Transaction ID: ${payment.id}`);
- * } else {
- *   console.error(`Payment failed: ${payment.error}`);
+ * } catch (error) {
+ *   console.error(`Payment failed: ${error.message}`);
  * }
  * ```
  */

--- a/packages/account-sdk/src/interface/payment/pay.ts
+++ b/packages/account-sdk/src/interface/payment/pay.ts
@@ -3,7 +3,6 @@ import {
   logPaymentError,
   logPaymentStarted,
 } from ':core/telemetry/events/payment.js';
-import type { Address } from 'viem';
 import type { PaymentOptions, PaymentResult } from './types.js';
 import { executePaymentWithSDK } from './utils/sdkManager.js';
 import { translatePaymentToSendCalls } from './utils/translatePayment.js';
@@ -103,12 +102,7 @@ export async function pay(options: PaymentOptions): Promise<PaymentResult> {
       logPaymentError({ amount, testnet, correlationId, errorMessage });
     }
 
-    // Return error result
-    return {
-      success: false,
-      error: errorMessage,
-      amount: amount,
-      to: to as Address,
-    };
+    // Re-throw the original error
+    throw error;
   }
 }

--- a/packages/account-sdk/src/interface/payment/types.ts
+++ b/packages/account-sdk/src/interface/payment/types.ts
@@ -138,8 +138,8 @@ export interface PaymentStatus {
   amount?: string;
   /** Recipient address (present for completed transactions, parsed from logs) */
   recipient?: string;
-  /** Error message (present for failed status - includes both on-chain failure reasons and off-chain errors) */
-  error?: string;
+  /** Reason for transaction failure (present for failed status - describes why the transaction failed on-chain) */
+  reason?: string;
 }
 
 /**


### PR DESCRIPTION
### _Summary_

Changes to pay function:
 - BREAKING: The pay function now throws errors instead of returning error result objects
Previously returned { success: false, error: string } objects on failure
Now throws the original error, allowing proper error handling with try/catch blocks


Changes to getPaymentStatus function:
 - BREAKING: Renamed the error field to reason in the PaymentStatus interface for transaction failures. Transaction failures (e.g., insufficient balance) still return a PaymentStatus object with status: 'failed' and a reason field
 - BREAKING: RPC errors, network errors, and other infrastructure failures now throw exceptions



### _How did you test your changes?_

Manually tested in a development setting - 

All existing tests have been updated to reflect the new error-throwing behavior. Added additional test cases to ensure proper handling of various error formats:

All tests passing
