### PR TITLE
Convert chain IDs to hexadecimal format

### DIFF
--- a/packages/account-sdk/src/interface/payment/constants.test.ts
+++ b/packages/account-sdk/src/interface/payment/constants.test.ts
@@ -12,8 +12,8 @@ describe('constants', () => {
 
   describe('CHAIN_IDS', () => {
     it('should have correct chain IDs', () => {
-      expect(CHAIN_IDS.base).toBe(8453);
-      expect(CHAIN_IDS.baseSepolia).toBe(84532);
+      expect(CHAIN_IDS.base).toBe(0x2105);
+      expect(CHAIN_IDS.baseSepolia).toBe(0x14a34);
     });
   });
 });

--- a/packages/account-sdk/src/interface/payment/constants.ts
+++ b/packages/account-sdk/src/interface/payment/constants.ts
@@ -15,8 +15,8 @@ export const TOKENS = {
  * Chain IDs for supported networks
  */
 export const CHAIN_IDS = {
-  base: 8453,
-  baseSepolia: 84532,
+  base: 0x2105, // 8453 in hex
+  baseSepolia: 0x14a34, // 84532 in hex
 } as const;
 
 /**

--- a/packages/account-sdk/src/interface/payment/pay.test.ts
+++ b/packages/account-sdk/src/interface/payment/pay.test.ts
@@ -38,7 +38,7 @@ describe('pay', () => {
     vi.mocked(validation.validateStringAmount).mockReturnValue(undefined);
     vi.mocked(translatePayment.translatePaymentToSendCalls).mockReturnValue({
       version: '2.0.0',
-      chainId: 8453,
+      chainId: 0x2105,
       calls: [
         {
           to: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
@@ -171,7 +171,7 @@ describe('pay', () => {
     vi.mocked(validation.validateStringAmount).mockReturnValue(undefined);
     vi.mocked(translatePayment.translatePaymentToSendCalls).mockReturnValue({
       version: '2.0.0',
-      chainId: 8453,
+      chainId: 0x2105,
       calls: [],
       capabilities: {},
     });
@@ -192,7 +192,7 @@ describe('pay', () => {
     vi.mocked(validation.validateStringAmount).mockReturnValue(undefined);
     vi.mocked(translatePayment.translatePaymentToSendCalls).mockReturnValue({
       version: '2.0.0',
-      chainId: 8453,
+      chainId: 0x2105,
       calls: [
         {
           to: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
@@ -229,7 +229,7 @@ describe('pay', () => {
     vi.mocked(validation.validateStringAmount).mockReturnValue(undefined);
     vi.mocked(translatePayment.translatePaymentToSendCalls).mockReturnValue({
       version: '2.0.0',
-      chainId: 8453,
+      chainId: 0x2105,
       calls: [
         {
           to: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
@@ -283,7 +283,7 @@ describe('pay', () => {
     vi.mocked(validation.validateStringAmount).mockReturnValue(undefined);
     vi.mocked(translatePayment.translatePaymentToSendCalls).mockReturnValue({
       version: '2.0.0',
-      chainId: 8453,
+      chainId: 0x2105,
       calls: [],
       capabilities: {},
     });
@@ -343,7 +343,7 @@ describe('pay', () => {
     );
     expect(sdkManager.executePaymentWithSDK).toHaveBeenCalledWith(
       expect.objectContaining({
-        chainId: 84532,
+        chainId: 0x14a34,
         capabilities: expect.objectContaining({
           paymasterService: expect.any(Object),
         }),
@@ -375,7 +375,7 @@ describe('pay', () => {
     vi.mocked(validation.validateStringAmount).mockReturnValue(undefined);
     vi.mocked(translatePayment.translatePaymentToSendCalls).mockReturnValue({
       version: '2.0.0',
-      chainId: 8453,
+      chainId: 0x2105,
       calls: [
         {
           to: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',


### PR DESCRIPTION
### _Summary_

Converted chain IDs from decimal to hexadecimal format in payment constants and tests. This change updates the chain ID representation for Base (8453 → 0x2105) and Base Sepolia (84532 → 0x14a34) to use hexadecimal notation.

This works around a bug in the callbackUrl endpoint which expects a hex chainId

### _How did you test your changes?_

Unit tests have been updated to verify the hexadecimal chain IDs:
- Updated `constants.test.ts` to test for hexadecimal values
- Updated `pay.test.ts` to use hexadecimal chain IDs in mock data and assertions

All existing tests pass with the new format.
