### PR TITLE
feat: Set up Spend Permission Utilities + fetchPermissions

### DIFF
--- a/packages/account-sdk/package.json
+++ b/packages/account-sdk/package.json
@@ -26,6 +26,11 @@
       "import": "./dist/interface/payment/index.js",
       "require": "./dist/interface/payment/index.js"
     },
+    "./spend-permission": {
+      "types": "./dist/interface/public-utilities/spend-permission/index.d.ts",
+      "import": "./dist/interface/public-utilities/spend-permission/index.js",
+      "require": "./dist/interface/public-utilities/spend-permission/index.js"
+    },
     "./ui-assets": {
       "types": "./dist/ui/assets/index.d.ts",
       "import": "./dist/ui/assets/index.js",

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/index.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/index.ts
@@ -1,0 +1,1 @@
+export * from './methods/fetchPermissions.js';

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/fetchPermissions.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/fetchPermissions.test.ts
@@ -1,0 +1,198 @@
+import { ProviderInterface } from ':core/provider/interface.js';
+import {
+  FetchPermissionsResponse,
+  SpendPermission,
+} from ':core/rpc/coinbase_fetchSpendPermissions.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchPermissions } from './fetchPermissions.js';
+
+describe('fetchPermissions', () => {
+  let mockProvider: ProviderInterface;
+  let mockRequest: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequest = vi.fn();
+    mockProvider = {
+      request: mockRequest,
+      disconnect: vi.fn(),
+      emit: vi.fn(),
+      on: vi.fn(),
+      off: vi.fn(),
+      once: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      removeAllListeners: vi.fn(),
+      setMaxListeners: vi.fn(),
+      getMaxListeners: vi.fn(),
+      listeners: vi.fn(),
+      rawListeners: vi.fn(),
+      listenerCount: vi.fn(),
+      eventNames: vi.fn(),
+      prependListener: vi.fn(),
+      prependOnceListener: vi.fn(),
+    } as ProviderInterface;
+  });
+
+  describe('successful requests', () => {
+    it('should fetch permissions successfully', async () => {
+      const mockPermissions: SpendPermission[] = [
+        {
+          createdAt: 1234567890,
+          permissionHash: '0xabcdef123456',
+          signature: '0x987654321fedcba',
+          chainId: 8453,
+          permission: {
+            account: '0x1234567890abcdef1234567890abcdef12345678',
+            spender: '0x5678901234567890abcdef1234567890abcdef12',
+            token: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+            allowance: '1000000000000000000',
+            period: 86400,
+            start: 1234567890,
+            end: 1234654290,
+            salt: '123456789',
+            extraData: '0x',
+          },
+        },
+        {
+          createdAt: 1234567900,
+          permissionHash: '0xfedcba654321',
+          signature: '0xabcdef987654321',
+          chainId: 8453,
+          permission: {
+            account: '0x1234567890abcdef1234567890abcdef12345678',
+            spender: '0x5678901234567890abcdef1234567890abcdef12',
+            token: '0xa0b86a33e6ba1a1c7b8eb56c1b8b5a7b34d5f0c8',
+            allowance: '500000000000000000',
+            period: 3600,
+            start: 1234567900,
+            end: 1234571500,
+            salt: '987654321',
+            extraData: '0x1234',
+          },
+        },
+      ];
+
+      const mockResponse: FetchPermissionsResponse = {
+        permissions: mockPermissions,
+      };
+
+      mockRequest.mockResolvedValue(mockResponse);
+
+      const result = await fetchPermissions(
+        {
+          account: '0x1234567890abcdef1234567890abcdef12345678',
+          chainId: 8453,
+          spender: '0x5678901234567890abcdef1234567890abcdef12',
+        },
+        mockProvider
+      );
+
+      expect(result).toEqual(mockPermissions);
+      expect(result).toHaveLength(2);
+      expect(result[0].permission.account).toBe('0x1234567890abcdef1234567890abcdef12345678');
+      expect(result[1].permission.spender).toBe('0x5678901234567890abcdef1234567890abcdef12');
+    });
+
+    it('should return empty array when no permissions exist', async () => {
+      const mockResponse: FetchPermissionsResponse = {
+        permissions: [],
+      };
+
+      mockRequest.mockResolvedValue(mockResponse);
+
+      const result = await fetchPermissions(
+        {
+          account: '0x1234567890abcdef1234567890abcdef12345678',
+          chainId: 8453,
+          spender: '0x5678901234567890abcdef1234567890abcdef12',
+        },
+        mockProvider
+      );
+
+      expect(result).toEqual([]);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('parameter handling', () => {
+    it('should convert chainId to hex format correctly', async () => {
+      const mockResponse: FetchPermissionsResponse = {
+        permissions: [],
+      };
+
+      mockRequest.mockResolvedValue(mockResponse);
+
+      // Test different chainIds
+      const testCases = [
+        { input: 1, expected: '0x1' },
+        { input: 8453, expected: '0x2105' },
+        { input: 137, expected: '0x89' },
+        { input: 42161, expected: '0xa4b1' },
+      ];
+
+      for (const testCase of testCases) {
+        mockRequest.mockClear();
+
+        await fetchPermissions(
+          {
+            account: '0x1234567890abcdef1234567890abcdef12345678',
+            chainId: testCase.input,
+            spender: '0x5678901234567890abcdef1234567890abcdef12',
+          },
+          mockProvider
+        );
+
+        expect(mockRequest).toHaveBeenCalledWith({
+          method: 'coinbase_fetchPermissions',
+          params: [
+            {
+              account: '0x1234567890abcdef1234567890abcdef12345678',
+              chainId: testCase.expected,
+              spender: '0x5678901234567890abcdef1234567890abcdef12',
+            },
+          ],
+        });
+      }
+    });
+  });
+
+  describe('error handling', () => {
+    it('should propagate provider errors', async () => {
+      const errorMessage = 'Network error';
+      mockRequest.mockRejectedValue(new Error(errorMessage));
+
+      await expect(
+        fetchPermissions(
+          {
+            account: '0x1234567890abcdef1234567890abcdef12345678',
+            chainId: 8453,
+            spender: '0x5678901234567890abcdef1234567890abcdef12',
+          },
+          mockProvider
+        )
+      ).rejects.toThrow(errorMessage);
+    });
+
+    it('should handle RPC errors', async () => {
+      mockRequest.mockRejectedValue({
+        code: -32603,
+        message: 'Internal error',
+      });
+
+      await expect(
+        fetchPermissions(
+          {
+            account: '0x1234567890abcdef1234567890abcdef12345678',
+            chainId: 8453,
+            spender: '0x5678901234567890abcdef1234567890abcdef12',
+          },
+          mockProvider
+        )
+      ).rejects.toEqual({
+        code: -32603,
+        message: 'Internal error',
+      });
+    });
+  });
+});

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/fetchPermissions.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/fetchPermissions.ts
@@ -1,0 +1,63 @@
+import { ProviderInterface } from ':core/provider/interface.js';
+import {
+  FetchPermissionsResponse,
+  SpendPermission,
+} from ':core/rpc/coinbase_fetchSpendPermissions.js';
+
+type FetchPermissionsType = {
+  account: string;
+  chainId: number;
+  spender: string;
+};
+
+/**
+ * Fetches existing spend permissions for a specific account, spender, and chain.
+ *
+ * This helper method retrieves all spend permissions that have been granted by a specific
+ * account to a specific spender on a given chain. This is useful for checking existing
+ * permissions before creating new ones, or for displaying current allowances to users.
+ *
+ * The method uses the coinbase_fetchPermissions RPC method to query the permissions
+ * from the backend service.
+ *
+ * @param request - Configuration object containing account, chainId, and spender to query.
+ * @param provider - The provider interface used to make the coinbase_fetchPermissions request.
+ *
+ * @returns A promise that resolves to an array of SpendPermission objects.
+ *
+ * @example
+ * ```typescript
+ * import { fetchPermissions } from '@base-org/account/spend-permission';
+ *
+ * // Fetch all permissions for an account-spender pair
+ * const permissions = await fetchPermissions({
+ *   account: '0x1234...',
+ *   spender: '0x5678...',
+ *   chainId: 8453 // Base mainnet
+ * }, provider);
+ *
+ * console.log(`Found ${permissions.length} permissions`);
+ * permissions.forEach(permission => {
+ *   console.log(`Token: ${permission.permission.token}`);
+ * });
+ * ```
+ */
+export const fetchPermissions = async (
+  request: FetchPermissionsType,
+  provider: ProviderInterface
+): Promise<SpendPermission[]> => {
+  const { account, chainId, spender } = request;
+
+  const response = (await provider.request({
+    method: 'coinbase_fetchPermissions',
+    params: [
+      {
+        account,
+        chainId: `0x${chainId.toString(16)}`,
+        spender,
+      },
+    ],
+  })) as FetchPermissionsResponse;
+
+  return response.permissions;
+};


### PR DESCRIPTION
### _Summary_

## Setup Spend Permission Utils and Fetch Functionality

### Summary
This PR introduces public utility functions for managing spend permissions, starting with the `fetchPermissions` method. This provides developers with a convenient way to query existing spend permissions for account-spender pairs on specific chains.

### Changes Made

#### 🔧 **New Public API**
- **Added new export**: `./spend-permission` entry point in `package.json` 
- **New utility function**: `fetchPermissions()` for querying existing spend permissions
- **Comprehensive test coverage**: Full test suite with edge cases and error handling

#### 📁 **File Changes**
- `packages/account-sdk/package.json` - Added new export entry for spend permission utilities
- `packages/account-sdk/src/interface/public-utilities/spend-permission/index.ts` - Main export file
- `packages/account-sdk/src/interface/public-utilities/spend-permission/methods/fetchPermissions.ts` - Implementation
- `packages/account-sdk/src/interface/public-utilities/spend-permission/methods/fetchPermissions.test.ts` - Test suite

### Features

#### `fetchPermissions()`
- **Purpose**: Retrieves all spend permissions granted by a specific account to a spender on a given chain
- **Use Cases**: 
  - Check existing permissions before creating new ones
  - Display current allowances to users
  - Audit spend permission usage
- **Parameters**: 
  - `account`: The account address that granted permissions
  - `chainId`: The chain ID (automatically converted to hex format)
  - `spender`: The spender address that received permissions
- **Returns**: Array of `SpendPermission` objects

#### Usage Example
```typescript
import { fetchPermissions } from '@base-org/account/spend-permission';

const permissions = await fetchPermissions({
  account: '0x1234...',
  spender: '0x5678...',
  chainId: 8453 // Base mainnet
}, provider);

console.log(`Found ${permissions.length} permissions`);
```

### Testing
- ✅ Successful permission fetching
- ✅ Empty result handling
- ✅ Chain ID format conversion (decimal to hex)
- ✅ Error propagation and RPC error handling
- ✅ Multiple test scenarios with different chain IDs

### Breaking Changes
None - this is a purely additive change that introduces new public utilities.

### Next Steps
This establishes the foundation for additional spend permission utilities. Future PRs may include:
- Permission creation utilities
- Permission revocation helpers
- Permission validation tools

### _How did you test your changes?_


<img width="869" height="281" alt="Screenshot 2025-07-31 at 2 18 20 PM" src="https://github.com/user-attachments/assets/20a67c7c-f87d-4bac-937e-aedb50de93d9" />

