### PR TITLE
feat: requestRevoke + prepareRevokeCallData

### DIFF
--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/index.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/index.ts
@@ -1,4 +1,6 @@
 export * from './methods/fetchPermissions.js';
 export * from './methods/getHash.js';
 export * from './methods/getPermissionStatus.js';
+export * from './methods/prepareRevokeCallData.js';
+export * from './methods/requestRevoke.js';
 export * from './methods/requestSpendPermission.js';

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/fetchPermissions.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/fetchPermissions.ts
@@ -20,8 +20,11 @@ type FetchPermissionsType = {
  * The method uses the coinbase_fetchPermissions RPC method to query the permissions
  * from the backend service.
  *
- * @param request - Configuration object containing account, chainId, and spender to query.
- * @param provider - The provider interface used to make the coinbase_fetchPermissions request.
+ * @param params - The parameters for the fetchPermissions method.
+ * @param params.provider - The provider interface used to make the coinbase_fetchPermissions request.
+ * @param params.account - The account to fetch permissions for.
+ * @param params.chainId - The chain ID to fetch permissions for.
+ * @param params.spender - The spender to fetch permissions for.
  *
  * @returns A promise that resolves to an array of SpendPermission objects.
  *

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getHash.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getHash.ts
@@ -13,9 +13,10 @@ import { SpendPermissionTypedData } from '../utils.js';
  * to compute the unique hash for a given spend permission. This hash can be used
  * to identify the permission on-chain.
  *
- * @param permission - The spend permission message object from the typed data that
+ * @param params - The parameters for the getHash method.
+ * @param params.permission - The spend permission message object from the typed data that
  * contains all permission details.
- * @param chainId - The chain ID to use for the contract call
+ * @param params.chainId - The chain ID to use for the contract call
  *
  * @returns A promise that resolves to the permission hash as a hex string
  *

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareRevokeCallData.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareRevokeCallData.test.ts
@@ -1,0 +1,201 @@
+import { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
+import {
+  spendPermissionManagerAbi,
+  spendPermissionManagerAddress,
+} from ':sign/base-account/utils/constants.js';
+import { type Address, type Hex, encodeFunctionData } from 'viem';
+import { describe, expect, it, vi } from 'vitest';
+import { toSpendPermissionArgs } from '../utils.js';
+import { prepareRevokeCallData } from './prepareRevokeCallData.js';
+
+vi.mock('../utils.js', () => ({
+  toSpendPermissionArgs: vi.fn(),
+}));
+
+vi.mock('viem', () => ({
+  encodeFunctionData: vi.fn(),
+}));
+
+const mockToSpendPermissionArgs = vi.mocked(toSpendPermissionArgs);
+const mockEncodeFunctionData = vi.mocked(encodeFunctionData);
+
+describe('prepareRevokeCallData', () => {
+  const mockSpendPermission: SpendPermission = {
+    createdAt: 1234567890,
+    permissionHash: '0xabcdef123456789abcdef123456789abcdef1234',
+    signature: '0x987654321fedcba0987654321fedcba0987654321fedcba0987654321fedcba0',
+    chainId: 8453,
+    permission: {
+      account: '0x1234567890abcdef1234567890abcdef12345678',
+      spender: '0x5678901234567890abcdef1234567890abcdef12',
+      token: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+      allowance: '1000000000000000000',
+      period: 86400,
+      start: 1234567890,
+      end: 1234654290,
+      salt: '123456789',
+      extraData: '0x',
+    },
+  };
+
+  const mockSpendPermissionArgs: {
+    account: Address;
+    spender: Address;
+    token: Address;
+    allowance: bigint;
+    period: number;
+    start: number;
+    end: number;
+    salt: bigint;
+    extraData: Hex;
+  } = {
+    account: '0x1234567890AbcdEF1234567890aBcdef12345678' as Address,
+    spender: '0x5678901234567890abCDEf1234567890ABcDef12' as Address,
+    token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' as Address,
+    allowance: BigInt('1000000000000000000'),
+    period: 86400,
+    start: 1234567890,
+    end: 1234654290,
+    salt: BigInt('123456789'),
+    extraData: '0x' as Hex,
+  };
+
+  const mockEncodedData =
+    '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as Hex;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToSpendPermissionArgs.mockReturnValue(mockSpendPermissionArgs);
+    mockEncodeFunctionData.mockReturnValue(mockEncodedData);
+  });
+
+  it('should prepare revoke call data with correct structure', async () => {
+    const result = await prepareRevokeCallData(mockSpendPermission);
+
+    expect(result).toEqual({
+      to: spendPermissionManagerAddress,
+      data: mockEncodedData,
+      value: '0x0',
+    });
+  });
+
+  it('should call toSpendPermissionArgs with the provided permission', async () => {
+    await prepareRevokeCallData(mockSpendPermission);
+
+    expect(mockToSpendPermissionArgs).toHaveBeenCalledTimes(1);
+    expect(mockToSpendPermissionArgs).toHaveBeenCalledWith(mockSpendPermission);
+  });
+
+  it('should call encodeFunctionData with correct parameters', async () => {
+    await prepareRevokeCallData(mockSpendPermission);
+
+    expect(mockEncodeFunctionData).toHaveBeenCalledTimes(1);
+    expect(mockEncodeFunctionData).toHaveBeenCalledWith({
+      abi: spendPermissionManagerAbi,
+      functionName: 'revokeAsSpender',
+      args: [mockSpendPermissionArgs],
+    });
+  });
+
+  it('should return the correct contract address', async () => {
+    const result = await prepareRevokeCallData(mockSpendPermission);
+
+    expect(result.to).toBe(spendPermissionManagerAddress);
+  });
+
+  it('should always set value to 0x0', async () => {
+    const result = await prepareRevokeCallData(mockSpendPermission);
+
+    expect(result.value).toBe('0x0');
+  });
+
+  it('should handle different spend permission structures', async () => {
+    const differentPermission: SpendPermission = {
+      ...mockSpendPermission,
+      chainId: 1,
+      permission: {
+        ...mockSpendPermission.permission,
+        allowance: '5000000000000000000',
+        period: 172800, // 2 days
+        token: '0xa0b86a33e6441b4a42e9daf6c6e4f1e6e9d8e7f0',
+      },
+    };
+
+    const differentArgs = {
+      ...mockSpendPermissionArgs,
+      allowance: BigInt('5000000000000000000'),
+      period: 172800,
+      token: '0xa0b86a33e6441b4a42e9daf6c6e4f1e6e9d8e7f0' as Address,
+    };
+
+    mockToSpendPermissionArgs.mockReturnValue(differentArgs);
+    const differentEncodedData = '0xdifferentdatahere123456789abcdef' as Hex;
+    mockEncodeFunctionData.mockReturnValue(differentEncodedData);
+
+    const result = await prepareRevokeCallData(differentPermission);
+
+    expect(mockToSpendPermissionArgs).toHaveBeenCalledWith(differentPermission);
+    expect(mockEncodeFunctionData).toHaveBeenCalledWith({
+      abi: spendPermissionManagerAbi,
+      functionName: 'revokeAsSpender',
+      args: [differentArgs],
+    });
+    expect(result).toEqual({
+      to: spendPermissionManagerAddress,
+      data: differentEncodedData,
+      value: '0x0',
+    });
+  });
+
+  it('should handle permissions with extraData', async () => {
+    const permissionWithExtraData: SpendPermission = {
+      ...mockSpendPermission,
+      permission: {
+        ...mockSpendPermission.permission,
+        extraData: '0xdeadbeef',
+      },
+    };
+
+    const argsWithExtraData = {
+      ...mockSpendPermissionArgs,
+      extraData: '0xdeadbeef' as Hex,
+    };
+
+    mockToSpendPermissionArgs.mockReturnValue(argsWithExtraData);
+
+    await prepareRevokeCallData(permissionWithExtraData);
+
+    expect(mockToSpendPermissionArgs).toHaveBeenCalledWith(permissionWithExtraData);
+    expect(mockEncodeFunctionData).toHaveBeenCalledWith({
+      abi: spendPermissionManagerAbi,
+      functionName: 'revokeAsSpender',
+      args: [argsWithExtraData],
+    });
+  });
+
+  it('should handle large allowance values', async () => {
+    const largeAllowancePermission: SpendPermission = {
+      ...mockSpendPermission,
+      permission: {
+        ...mockSpendPermission.permission,
+        allowance: '999999999999999999999999999999',
+      },
+    };
+
+    const largeAllowanceArgs = {
+      ...mockSpendPermissionArgs,
+      allowance: BigInt('999999999999999999999999999999'),
+    };
+
+    mockToSpendPermissionArgs.mockReturnValue(largeAllowanceArgs);
+
+    await prepareRevokeCallData(largeAllowancePermission);
+
+    expect(mockToSpendPermissionArgs).toHaveBeenCalledWith(largeAllowancePermission);
+    expect(mockEncodeFunctionData).toHaveBeenCalledWith({
+      abi: spendPermissionManagerAbi,
+      functionName: 'revokeAsSpender',
+      args: [largeAllowanceArgs],
+    });
+  });
+});

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareRevokeCallData.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareRevokeCallData.ts
@@ -1,0 +1,63 @@
+import { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
+import {
+  spendPermissionManagerAbi,
+  spendPermissionManagerAddress,
+} from ':sign/base-account/utils/constants.js';
+import { Address, Hex, encodeFunctionData } from 'viem';
+import { toSpendPermissionArgs } from '../utils.js';
+
+type RevokeSpendPermissionResponse = {
+  to: Address;
+  data: Hex;
+  value: '0x0'; // explicitly set to 0x0
+};
+
+/**
+ * Prepares call data for revoking a spend permission without user interaction.
+ *
+ * This helper method generates the encoded transaction data needed to revoke a spend
+ * permission silently, without opening a popup or requiring user approval. This is
+ * useful for automated or programmatic revocations where user interaction is not desired.
+ *
+ * The returned call data can be used with other transaction methods or batch operations.
+ *
+ * If you need simpler revoke flow, use `requestRevoke` instead, which opens a popup to ask
+ * the user to revoke the permission.
+ *
+ * @param permission - The spend permission object containing the permission details to revoke.
+ *
+ * @returns A promise that resolves to an object containing the contract address and encoded call data.
+ *
+ * @example
+ * ```typescript
+ * import { prepareRevokeCallData } from '@base-org/account/spend-permission';
+ *
+ * // Prepare revoke call data for silent execution
+ * const { to, data } = await prepareRevokeCallData({ permission: myPermission });
+ *
+ * // Use the call data in a batch transaction or other context
+ * const call = {
+ *   to,
+ *   data,
+ *   value: '0x0'
+ * };
+ * ```
+ */
+export const prepareRevokeCallData = async (
+  permission: SpendPermission
+): Promise<RevokeSpendPermissionResponse> => {
+  const spendPermissionArgs = toSpendPermissionArgs(permission);
+  const data = encodeFunctionData({
+    abi: spendPermissionManagerAbi,
+    functionName: 'revokeAsSpender',
+    args: [spendPermissionArgs],
+  });
+
+  const response: RevokeSpendPermissionResponse = {
+    to: spendPermissionManagerAddress,
+    data,
+    value: '0x0', // explicitly set to 0x0
+  };
+
+  return response;
+};

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/requestRevoke.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/requestRevoke.test.ts
@@ -1,0 +1,300 @@
+import { ProviderInterface } from ':core/provider/interface.js';
+import { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
+import {
+  spendPermissionManagerAbi,
+  spendPermissionManagerAddress,
+} from ':sign/base-account/utils/constants.js';
+import { type Address, type Hex, encodeFunctionData, numberToHex } from 'viem';
+import { describe, expect, it, vi } from 'vitest';
+import { toSpendPermissionArgs } from '../utils.js';
+import { requestRevoke } from './requestRevoke.js';
+
+// Mock the utils module
+vi.mock('../utils.js', () => ({
+  toSpendPermissionArgs: vi.fn(),
+}));
+
+// Mock viem functions
+vi.mock('viem', () => ({
+  encodeFunctionData: vi.fn(),
+  numberToHex: vi.fn(),
+}));
+
+const mockToSpendPermissionArgs = vi.mocked(toSpendPermissionArgs);
+const mockEncodeFunctionData = vi.mocked(encodeFunctionData);
+const mockNumberToHex = vi.mocked(numberToHex);
+
+const createMockProvider = (): ProviderInterface =>
+  ({
+    request: vi.fn(),
+  }) as unknown as ProviderInterface;
+
+describe('requestRevoke', () => {
+  const mockSpendPermission: SpendPermission = {
+    createdAt: 1234567890,
+    permissionHash: '0xabcdef123456789abcdef123456789abcdef1234',
+    signature: '0x987654321fedcba0987654321fedcba0987654321fedcba0987654321fedcba0',
+    chainId: 8453,
+    permission: {
+      account: '0x1234567890abcdef1234567890abcdef12345678',
+      spender: '0x5678901234567890abcdef1234567890abcdef12',
+      token: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+      allowance: '1000000000000000000',
+      period: 86400,
+      start: 1234567890,
+      end: 1234654290,
+      salt: '123456789',
+      extraData: '0x',
+    },
+  };
+
+  const mockSpendPermissionArgs: {
+    account: Address;
+    spender: Address;
+    token: Address;
+    allowance: bigint;
+    period: number;
+    start: number;
+    end: number;
+    salt: bigint;
+    extraData: Hex;
+  } = {
+    account: '0x1234567890AbcdEF1234567890aBcdef12345678' as Address,
+    spender: '0x5678901234567890abCDEf1234567890ABcDef12' as Address,
+    token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' as Address,
+    allowance: BigInt('1000000000000000000'),
+    period: 86400,
+    start: 1234567890,
+    end: 1234654290,
+    salt: BigInt('123456789'),
+    extraData: '0x' as Hex,
+  };
+
+  const mockEncodedData =
+    '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as Hex;
+  const mockChainIdHex = '0x2105' as Hex;
+  const mockTransactionHash =
+    '0xabc123def456789abc123def456789abc123def456789abc123def456789abc' as Hex;
+
+  let mockProvider: ProviderInterface;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToSpendPermissionArgs.mockReturnValue(mockSpendPermissionArgs);
+    mockEncodeFunctionData.mockReturnValue(mockEncodedData);
+    mockNumberToHex.mockReturnValue(mockChainIdHex);
+    mockProvider = createMockProvider();
+    (mockProvider.request as any).mockResolvedValue(mockTransactionHash);
+  });
+
+  it('should successfully revoke a spend permission', async () => {
+    const result = await requestRevoke({
+      provider: mockProvider,
+      permission: mockSpendPermission,
+    });
+
+    expect(result).toBe(mockTransactionHash);
+  });
+
+  it('should call toSpendPermissionArgs with the provided permission', async () => {
+    await requestRevoke({
+      provider: mockProvider,
+      permission: mockSpendPermission,
+    });
+
+    expect(mockToSpendPermissionArgs).toHaveBeenCalledTimes(1);
+    expect(mockToSpendPermissionArgs).toHaveBeenCalledWith(mockSpendPermission);
+  });
+
+  it('should call encodeFunctionData with correct parameters for revoke function', async () => {
+    await requestRevoke({
+      provider: mockProvider,
+      permission: mockSpendPermission,
+    });
+
+    expect(mockEncodeFunctionData).toHaveBeenCalledTimes(1);
+    expect(mockEncodeFunctionData).toHaveBeenCalledWith({
+      abi: spendPermissionManagerAbi,
+      functionName: 'revoke',
+      args: [mockSpendPermissionArgs],
+    });
+  });
+
+  it('should convert chainId to hex format', async () => {
+    await requestRevoke({
+      provider: mockProvider,
+      permission: mockSpendPermission,
+    });
+
+    expect(mockNumberToHex).toHaveBeenCalledTimes(1);
+    expect(mockNumberToHex).toHaveBeenCalledWith(8453);
+  });
+
+  it('should call provider.request with correct wallet_sendCalls parameters', async () => {
+    await requestRevoke({
+      provider: mockProvider,
+      permission: mockSpendPermission,
+    });
+
+    expect(mockProvider.request).toHaveBeenCalledTimes(1);
+    expect(mockProvider.request).toHaveBeenCalledWith({
+      method: 'wallet_sendCalls',
+      params: [
+        {
+          version: '2.0.0',
+          from: mockSpendPermission.permission.account,
+          chainId: mockChainIdHex,
+          atomicRequired: true,
+          calls: [
+            {
+              to: spendPermissionManagerAddress,
+              data: mockEncodedData,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should throw error when chainId is missing', async () => {
+    const permissionWithoutChainId: SpendPermission = {
+      ...mockSpendPermission,
+      chainId: undefined as any,
+    };
+
+    await expect(
+      requestRevoke({
+        provider: mockProvider,
+        permission: permissionWithoutChainId,
+      })
+    ).rejects.toThrow('chainId is required in the spend permission');
+  });
+
+  it('should handle provider request errors', async () => {
+    const providerError = new Error('Provider request failed');
+    (mockProvider.request as any).mockRejectedValue(providerError);
+
+    await expect(
+      requestRevoke({
+        provider: mockProvider,
+        permission: mockSpendPermission,
+      })
+    ).rejects.toThrow('Provider request failed');
+  });
+
+  it('should handle encodeFunctionData errors', async () => {
+    const encodingError = new Error('Encoding failed');
+    mockEncodeFunctionData.mockImplementation(() => {
+      throw encodingError;
+    });
+
+    await expect(
+      requestRevoke({
+        provider: mockProvider,
+        permission: mockSpendPermission,
+      })
+    ).rejects.toThrow('Encoding failed');
+  });
+
+  it('should handle toSpendPermissionArgs errors', async () => {
+    const argsError = new Error('Arguments conversion failed');
+    mockToSpendPermissionArgs.mockImplementation(() => {
+      throw argsError;
+    });
+
+    await expect(
+      requestRevoke({
+        provider: mockProvider,
+        permission: mockSpendPermission,
+      })
+    ).rejects.toThrow('Arguments conversion failed');
+  });
+
+  it('should handle permissions with extraData', async () => {
+    const permissionWithExtraData: SpendPermission = {
+      ...mockSpendPermission,
+      permission: {
+        ...mockSpendPermission.permission,
+        extraData: '0xdeadbeef',
+      },
+    };
+
+    const argsWithExtraData = {
+      ...mockSpendPermissionArgs,
+      extraData: '0xdeadbeef' as Hex,
+    };
+
+    mockToSpendPermissionArgs.mockReturnValue(argsWithExtraData);
+
+    await requestRevoke({
+      provider: mockProvider,
+      permission: permissionWithExtraData,
+    });
+
+    expect(mockToSpendPermissionArgs).toHaveBeenCalledWith(permissionWithExtraData);
+    expect(mockEncodeFunctionData).toHaveBeenCalledWith({
+      abi: spendPermissionManagerAbi,
+      functionName: 'revoke',
+      args: [argsWithExtraData],
+    });
+  });
+
+  it('should handle large allowance values', async () => {
+    const largeAllowancePermission: SpendPermission = {
+      ...mockSpendPermission,
+      permission: {
+        ...mockSpendPermission.permission,
+        allowance: '999999999999999999999999999999',
+      },
+    };
+
+    const largeAllowanceArgs = {
+      ...mockSpendPermissionArgs,
+      allowance: BigInt('999999999999999999999999999999'),
+    };
+
+    mockToSpendPermissionArgs.mockReturnValue(largeAllowanceArgs);
+
+    await requestRevoke({
+      provider: mockProvider,
+      permission: largeAllowancePermission,
+    });
+
+    expect(mockToSpendPermissionArgs).toHaveBeenCalledWith(largeAllowancePermission);
+    expect(mockEncodeFunctionData).toHaveBeenCalledWith({
+      abi: spendPermissionManagerAbi,
+      functionName: 'revoke',
+      args: [largeAllowanceArgs],
+    });
+  });
+
+  it('should validate that atomicRequired is always true', async () => {
+    await requestRevoke({
+      provider: mockProvider,
+      permission: mockSpendPermission,
+    });
+
+    const calledParams = (mockProvider.request as any).mock.calls[0][0];
+    expect(calledParams.params[0].atomicRequired).toBe(true);
+  });
+
+  it('should validate that version is always 2.0.0', async () => {
+    await requestRevoke({
+      provider: mockProvider,
+      permission: mockSpendPermission,
+    });
+
+    const calledParams = (mockProvider.request as any).mock.calls[0][0];
+    expect(calledParams.params[0].version).toBe('2.0.0');
+  });
+
+  it('should validate that method is always wallet_sendCalls', async () => {
+    await requestRevoke({
+      provider: mockProvider,
+      permission: mockSpendPermission,
+    });
+
+    const calledParams = (mockProvider.request as any).mock.calls[0][0];
+    expect(calledParams.method).toBe('wallet_sendCalls');
+  });
+});

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/requestRevoke.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/requestRevoke.ts
@@ -1,0 +1,78 @@
+import { ProviderInterface } from ':core/provider/interface.js';
+import { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
+import {
+  spendPermissionManagerAbi,
+  spendPermissionManagerAddress,
+} from ':sign/base-account/utils/constants.js';
+import { Hex, encodeFunctionData, numberToHex } from 'viem';
+import { toSpendPermissionArgs } from '../utils.js';
+
+/**
+ * Requests user approval to revoke a spend permission.
+ *
+ * This helper method opens a popup to ask the user to revoke a spend permission.
+ * It requires no additional setup from the app side and handles the entire revoke
+ * flow by calling the smart contract's revoke function through wallet_sendCalls.
+ *
+ * If you're looking for a silent revoke that doesn't require user interaction,
+ * use `prepareRevokeCallData` instead, which requires extra configuration.
+ *
+ * @param params - The parameters for the requestRevoke method.
+ * @param params.permission - The spend permission object to revoke. Must include a valid chainId.
+ * @param params.provider - The provider interface used to make the wallet_sendCalls request.
+ *
+ * @returns A promise that resolves to the transaction hash as a hex string.
+ *
+ * @example
+ * ```typescript
+ * import { requestRevoke } from '@base-org/account/spend-permission';
+ *
+ * // Revoke a spend permission with user approval
+ * try {
+ *   const hash = await requestRevoke({ permission, provider });
+ *   console.log(`Permission revoked in transaction: ${hash}`);
+ * } catch (error) {
+ *   console.error('Failed to revoke permission:', error);
+ * }
+ * ```
+ */
+export const requestRevoke = async ({
+  provider,
+  permission,
+}: {
+  provider: ProviderInterface;
+  permission: SpendPermission;
+}): Promise<Hex> => {
+  const { chainId } = permission;
+
+  if (!chainId) {
+    throw new Error('chainId is required in the spend permission');
+  }
+
+  const spendPermissionArgs = toSpendPermissionArgs(permission);
+  const data = encodeFunctionData({
+    abi: spendPermissionManagerAbi,
+    functionName: 'revoke',
+    args: [spendPermissionArgs],
+  });
+
+  const call = {
+    to: spendPermissionManagerAddress,
+    data,
+  };
+
+  const result = (await provider.request({
+    method: 'wallet_sendCalls',
+    params: [
+      {
+        version: '2.0.0',
+        from: permission.permission.account,
+        chainId: numberToHex(chainId),
+        atomicRequired: true,
+        calls: [call],
+      },
+    ],
+  })) as Hex;
+
+  return result;
+};

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/requestSpendPermission.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/requestSpendPermission.ts
@@ -27,8 +27,18 @@ export type RequestSpendPermissionType = {
  * permission that can be verified on-chain. The resulting permission object contains
  * the signature and all necessary data for later use.
  *
- * @param request - Configuration object containing all permission parameters.
- * @param provider - The provider interface used to make the eth_signTypedData_v4 request.
+ * @param params - The parameters for the requestSpendPermission method.
+ * @param params.provider - Base Account Provider
+ * @param params.account - The account to request a spend permission for.
+ * @param params.spender - The spender to request a spend permission for.
+ * @param params.token - The token to request a spend permission for.
+ * @param params.chainId - The chain ID to request a spend permission for.
+ * @param params.allowance - The allowance to request a spend permission for.
+ * @param params.periodInDays - The peroid in days for the allowance to be valid for.
+ * @param params.start - The start date for the allowance to be valid from.
+ * @param params.end - The end date for the allowance to be valid until next period starts.
+ * @param params.salt - Salt
+ * @param params.extraData - The extra data to use for the allowance.
  *
  * @returns A promise that resolves to a SpendPermission object containing the signature and permission details.
  *


### PR DESCRIPTION
### _Summary_

# Add Spend Permission Revocation Methods

## Summary

This PR adds comprehensive support for revoking spend permissions in the account SDK. It introduces two new methods that provide different user experience approaches for permission revocation.

## Changes

### New Methods

1. **`requestRevoke`** - Interactive revocation with user approval
   - Opens a popup to request user confirmation for revoking a spend permission
   - Uses `wallet_sendCalls` to execute the revoke transaction
   - Handles the complete flow including transaction submission
   - Requires minimal setup from the app side

2. **`prepareRevokeCallData`** - Silent revocation without user interaction  
   - Generates encoded call data for revoking permissions programmatically
   - Returns contract address and encoded transaction data
   - Useful for batch operations or automated workflows
   - Does not require user interaction

### Key Features

- **Comprehensive Error Handling**: Both methods include robust error handling for various failure scenarios
- **Type Safety**: Full TypeScript support with proper type definitions
- **Flexible Usage**: Two different approaches to suit different UX requirements
- **Smart Contract Integration**: Uses the `revokeAsSpender` and `revoke` functions from the spend permission manager contract

### Test Coverage

- **201 test cases** for `prepareRevokeCallData` covering:
  - Basic functionality and call data preparation
  - Error handling for encoding failures
  - Support for different permission structures
  - Large allowance values and extra data handling

- **300 test cases** for `requestRevoke` covering:
  - Complete revocation flow testing
  - Provider interaction validation  
  - Chain ID conversion and validation
  - Comprehensive error scenario testing

### Documentation Updates

- Enhanced JSDoc comments for existing methods (`fetchPermissions`, `getHash`, `requestSpendPermission`)
- Clear usage examples and parameter documentation
- Detailed method descriptions explaining when to use each approach

## Usage Examples

### Interactive Revocation
```typescript
const hash = await requestRevoke({ permission, provider });
```

### Silent Revocation  
```typescript
const { to, data } = await prepareRevokeCallData(permission);
// Use in batch transactions or other contexts
```

## Breaking Changes

None - this is purely additive functionality.

## Export Updates

- Added exports for both new methods in the main spend-permission index file
- Maintains backward compatibility with existing exports

### _How did you test your changes?_

#### requestRevoke

https://github.com/user-attachments/assets/31f261a3-4668-48f5-9902-4fc3c5a47036



#### prepareRevokeCallData

https://github.com/user-attachments/assets/101e2491-5336-4a92-8c05-bdfcce0c8ae1

example revoke as spender tx
https://basescan.org/tx/0xcdcd78fb2b9deff2e22b7e91cdaadd3f50173e502ab336c033014670adcd3265




