### PR TITLE
Increase payment decimal precision to 6 places

### DIFF
--- a/packages/account-sdk/src/interface/payment/pay.test.ts
+++ b/packages/account-sdk/src/interface/payment/pay.test.ts
@@ -66,7 +66,7 @@ describe('pay', () => {
       payerInfoResponses: undefined,
     });
 
-    expect(validation.validateStringAmount).toHaveBeenCalledWith('10.50', 2);
+    expect(validation.validateStringAmount).toHaveBeenCalledWith('10.50', 6);
     expect(validation.normalizeAddress).toHaveBeenCalledWith(
       '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51'
     );
@@ -136,6 +136,43 @@ describe('pay', () => {
       false,
       undefined
     );
+  });
+
+  it('should accept amounts with up to 6 decimal places', async () => {
+    // Setup mocks
+    vi.mocked(validation.validateStringAmount).mockReturnValue(undefined);
+    vi.mocked(translatePayment.translatePaymentToSendCalls).mockReturnValue({
+      version: '2.0.0',
+      chainId: 8453,
+      calls: [
+        {
+          to: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          data: '0xabcdef',
+          value: '0x0',
+        },
+      ],
+      capabilities: {},
+    });
+    vi.mocked(sdkManager.executePaymentWithSDK).mockResolvedValue({
+      transactionHash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    });
+
+    // Test with 6 decimal places
+    const payment = await pay({
+      amount: '10.123456',
+      to: '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51',
+      testnet: false,
+    });
+
+    expect(payment).toEqual({
+      success: true,
+      id: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+      amount: '10.123456',
+      to: '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51',
+      payerInfoResponses: undefined,
+    });
+
+    expect(validation.validateStringAmount).toHaveBeenCalledWith('10.123456', 6);
   });
 
   it('should handle validation errors', async () => {
@@ -413,7 +450,7 @@ describe('pay', () => {
       payerInfoResponses: payerInfoResponses,
     });
 
-    expect(validation.validateStringAmount).toHaveBeenCalledWith('10.50', 2);
+    expect(validation.validateStringAmount).toHaveBeenCalledWith('10.50', 6);
     expect(validation.normalizeAddress).toHaveBeenCalledWith(
       '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51'
     );

--- a/packages/account-sdk/src/interface/payment/pay.ts
+++ b/packages/account-sdk/src/interface/payment/pay.ts
@@ -46,7 +46,7 @@ export async function pay(options: PaymentOptions): Promise<PaymentResult> {
   }
 
   try {
-    validateStringAmount(amount, 2);
+    validateStringAmount(amount, 6);
     const normalizedAddress = normalizeAddress(to);
 
     // Step 2: Translate payment to sendCalls format

--- a/packages/account-sdk/src/interface/payment/utils/validation.test.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.test.ts
@@ -3,23 +3,39 @@ import { normalizeAddress, validateStringAmount } from './validation.js';
 
 describe('validateStringAmount', () => {
   it('should validate valid amounts', () => {
-    expect(() => validateStringAmount('10.50', 2)).not.toThrow();
-    expect(() => validateStringAmount('0.01', 2)).not.toThrow();
-    expect(() => validateStringAmount('1000', 2)).not.toThrow();
-    expect(() => validateStringAmount('1.2', 2)).not.toThrow();
+    expect(() => validateStringAmount('10.50', 6)).not.toThrow();
+    expect(() => validateStringAmount('0.01', 6)).not.toThrow();
+    expect(() => validateStringAmount('1000', 6)).not.toThrow();
+    expect(() => validateStringAmount('1.2', 6)).not.toThrow();
+    expect(() => validateStringAmount('10.123456', 6)).not.toThrow();
+    expect(() => validateStringAmount('0.000001', 6)).not.toThrow();
   });
 
   it('should reject invalid amounts', () => {
-    expect(() => validateStringAmount('0', 2)).toThrow('Invalid amount: must be greater than 0');
-    expect(() => validateStringAmount('-10', 2)).toThrow('Invalid amount: must be greater than 0');
-    expect(() => validateStringAmount('abc', 2)).toThrow('Invalid amount: must be a valid number');
-    expect(() => validateStringAmount('10.123', 2)).toThrow(
-      'Invalid amount: pay only supports up to 2 decimal places'
+    expect(() => validateStringAmount('0', 6)).toThrow('Invalid amount: must be greater than 0');
+    expect(() => validateStringAmount('-10', 6)).toThrow('Invalid amount: must be greater than 0');
+    expect(() => validateStringAmount('abc', 6)).toThrow('Invalid amount: must be a valid number');
+    expect(() => validateStringAmount('10.1234567', 6)).toThrow(
+      'Invalid amount: pay only supports up to 6 decimal places'
     );
   });
 
   it('should reject non-string amounts', () => {
-    expect(() => validateStringAmount(10 as any, 2)).toThrow('Invalid amount: must be a string');
+    expect(() => validateStringAmount(10 as any, 6)).toThrow('Invalid amount: must be a string');
+  });
+
+  it('should validate amounts with exactly 6 decimal places', () => {
+    expect(() => validateStringAmount('1.123456', 6)).not.toThrow();
+    expect(() => validateStringAmount('999.999999', 6)).not.toThrow();
+    expect(() => validateStringAmount('0.100000', 6)).not.toThrow();
+  });
+
+  it('should validate amounts with fewer than 6 decimal places', () => {
+    expect(() => validateStringAmount('1.1', 6)).not.toThrow();
+    expect(() => validateStringAmount('1.12', 6)).not.toThrow();
+    expect(() => validateStringAmount('1.123', 6)).not.toThrow();
+    expect(() => validateStringAmount('1.1234', 6)).not.toThrow();
+    expect(() => validateStringAmount('1.12345', 6)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## What changed? Why?

Updated the payment validation logic to support 6 decimal places instead of 2. This change allows for more precise payment amounts, particularly useful for smaller denominations and microtransactions.

Key changes:
- Modified `validateStringAmount` calls in `pay.ts` to accept 6 decimal places
- Updated all related test cases to validate amounts with up to 6 decimal places
- Added new test case to verify 6 decimal place amounts are properly handled

## How was this tested?

Test coverage includes:
- Updated existing unit tests in `pay.test.ts` to validate 6 decimal places
- Added new test case "should accept amounts with up to 6 decimal places" to verify the functionality
- Updated validation tests in `validation.test.ts` with comprehensive test cases for 1-6 decimal places
- All existing tests pass with the new decimal precision

## How can reviewers manually test these changes?

1. Run the test suite: `yarn test packages/account-sdk/src/interface/payment`
2. Test payment functionality with various decimal precisions:
   - Amounts with 1-5 decimal places (should work as before)
   - Amounts with exactly 6 decimal places (e.g., 10.123456)
   - Amounts with more than 6 decimal places (should throw validation error)

## Demo/screenshots


<img width="416" height="762" alt="Screenshot 2025-08-11 at 3 00 57 PM" src="https://github.com/user-attachments/assets/fc041d8c-39c7-4e7a-b461-d9a2b3012020" />



