### PR TITLE
fix: do not return cached wallet_connect response when SIWE capability present

### DIFF
--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -250,10 +250,14 @@ export class Signer {
       case 'wallet_grantPermissions':
         return this.sendRequestToPopup(request);
       case 'wallet_connect': {
-        // Return cached wallet connect response if available
-        const cachedResponse = await getCachedWalletConnectResponse();
-        if (cachedResponse) {
-          return cachedResponse;
+        // Return cached wallet connect response if available, unless signInWithEthereum capability is present
+        // SIWE requires fresh signatures/nonces so we should not use cached responses
+        const hasSiweCapability = requestHasCapability(request, 'signInWithEthereum');
+        if (!hasSiweCapability) {
+          const cachedResponse = await getCachedWalletConnectResponse();
+          if (cachedResponse) {
+            return cachedResponse;
+          }
         }
 
         // Wait for the popup to be loaded before making async calls


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

Updated the wallet_connect RPC handler to not return a cached response when the signInWithEthereum capability is present.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
Unit tests, manually verified functionality in playground
