### PR TITLE
Expose getPaymentStatus to Node envs

### DIFF
--- a/packages/account-sdk/package.json
+++ b/packages/account-sdk/package.json
@@ -21,10 +21,27 @@
       "import": "./dist/index.js",
       "require": "./dist/index.js"
     },
-    "./payment": {
+    "./payment/browser": {
       "types": "./dist/interface/payment/index.d.ts",
       "import": "./dist/interface/payment/index.js",
       "require": "./dist/interface/payment/index.js"
+    },
+    "./payment/node": {
+      "types": "./dist/interface/payment/index.node.d.ts",
+      "import": "./dist/interface/payment/index.node.js",
+      "require": "./dist/interface/payment/index.node.js"
+    },
+    "./payment": {
+      "browser": {
+        "types": "./dist/interface/payment/index.d.ts",
+        "import": "./dist/interface/payment/index.js",
+        "require": "./dist/interface/payment/index.js"
+      },
+      "node": {
+        "types": "./dist/interface/payment/index.node.d.ts",
+        "import": "./dist/interface/payment/index.node.js",
+        "require": "./dist/interface/payment/index.node.js"
+      }
     },
     "./spend-permission/browser": {
       "types": "./dist/interface/public-utilities/spend-permission/index.d.ts",

--- a/packages/account-sdk/src/interface/payment/index.node.ts
+++ b/packages/account-sdk/src/interface/payment/index.node.ts
@@ -1,0 +1,4 @@
+/**
+ * Payment interface exports for Node.js environment
+ */
+export { getPaymentStatus } from './getPaymentStatus.js';


### PR DESCRIPTION
## What changed? Why?

Added Node.js-specific export configuration for the payment module in the account-sdk package. 

## How was this tested?

Module resolution and export configuration changes validated through build process.

## How can reviewers manually test these changes?

1. Import the payment module in a Node.js environment: `import { getPaymentStatus } from '@base/account-sdk/payment'`
2. Import the payment module in a browser environment to verify existing functionality remains intact

## Demo/screenshots


