### PR TITLE
Support setting external correlation ID

### DIFF
--- a/packages/account-sdk/src/index.ts
+++ b/packages/account-sdk/src/index.ts
@@ -3,6 +3,8 @@ export type { AppMetadata, Preference, ProviderInterface } from ':core/provider/
 
 export { createBaseAccountSDK } from './interface/builder/core/createBaseAccountSDK.js';
 
+export { externalCorrelationIds } from './store/external-correlation-id/store.js';
+
 export { getCryptoKeyAccount, removeCryptoKey } from './kms/crypto-key/index.js';
 
 // Payment interface exports
@@ -16,5 +18,5 @@ export type {
   PaymentStatus,
   PaymentStatusOptions,
   PaymentStatusType,
-  PaymentSuccess,
+  PaymentSuccess
 } from './interface/payment/index.js';

--- a/packages/account-sdk/src/index.ts
+++ b/packages/account-sdk/src/index.ts
@@ -18,5 +18,5 @@ export type {
   PaymentStatus,
   PaymentStatusOptions,
   PaymentStatusType,
-  PaymentSuccess
+  PaymentSuccess,
 } from './interface/payment/index.js';

--- a/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.test.ts
+++ b/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.test.ts
@@ -113,6 +113,26 @@ describe('Ephemeral methods', () => {
       expect(mockCleanup).toHaveBeenCalled();
     }
   );
+
+  it.each(['wallet_sendCalls', 'wallet_sign'])(
+    'should extract and store paymentLinkId when present in params',
+    async (method) => {
+      const paymentLinkId = 'payment_link_12345';
+      const args = { 
+        method, 
+        params: [{ paymentLinkId, otherParam: 'value' }] 
+      };
+      
+      store.config.set({ paymentLinkId: undefined });
+      
+      await provider.request(args);
+      
+      expect(store.config.get().paymentLinkId).toBe(paymentLinkId);
+      expect(mockHandshake).toHaveBeenCalledWith({ method: 'handshake' });
+      expect(mockRequest).toHaveBeenCalledWith(args);
+      expect(mockCleanup).toHaveBeenCalled();
+    }
+  );
 });
 
 describe('Auto sub account', () => {

--- a/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.test.ts
+++ b/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.test.ts
@@ -113,26 +113,6 @@ describe('Ephemeral methods', () => {
       expect(mockCleanup).toHaveBeenCalled();
     }
   );
-
-  it.each(['wallet_sendCalls', 'wallet_sign'])(
-    'should extract and store paymentLinkId when present in params',
-    async (method) => {
-      const paymentLinkId = 'payment_link_12345';
-      const args = {
-        method,
-        params: [{ paymentLinkId, otherParam: 'value' }],
-      };
-
-      store.config.set({ paymentLinkId: undefined });
-
-      await provider.request(args);
-
-      expect(store.config.get().paymentLinkId).toBe(paymentLinkId);
-      expect(mockHandshake).toHaveBeenCalledWith({ method: 'handshake' });
-      expect(mockRequest).toHaveBeenCalledWith(args);
-      expect(mockCleanup).toHaveBeenCalled();
-    }
-  );
 });
 
 describe('Auto sub account', () => {

--- a/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.test.ts
+++ b/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.test.ts
@@ -118,15 +118,15 @@ describe('Ephemeral methods', () => {
     'should extract and store paymentLinkId when present in params',
     async (method) => {
       const paymentLinkId = 'payment_link_12345';
-      const args = { 
-        method, 
-        params: [{ paymentLinkId, otherParam: 'value' }] 
+      const args = {
+        method,
+        params: [{ paymentLinkId, otherParam: 'value' }],
       };
-      
+
       store.config.set({ paymentLinkId: undefined });
-      
+
       await provider.request(args);
-      
+
       expect(store.config.get().paymentLinkId).toBe(paymentLinkId);
       expect(mockHandshake).toHaveBeenCalledWith({ method: 'handshake' });
       expect(mockRequest).toHaveBeenCalledWith(args);

--- a/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
+++ b/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
@@ -101,6 +101,12 @@ export class BaseAccountProvider extends ProviderEventEmitter implements Provide
           }
           case 'wallet_sendCalls':
           case 'wallet_sign': {
+            // Extract and store paymentLinkId if present in the request params
+            const paymentLinkId = (args.params as any)?.[0]?.paymentLinkId;
+            if (paymentLinkId) {
+              store.config.set({ paymentLinkId });
+            }
+            
             try {
               await this.signer.handshake({ method: 'handshake' }); // exchange session keys
               const result = await this.signer.request(args); // send diffie-hellman encrypted request

--- a/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
+++ b/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
@@ -106,7 +106,7 @@ export class BaseAccountProvider extends ProviderEventEmitter implements Provide
             if (paymentLinkId) {
               store.config.set({ paymentLinkId });
             }
-            
+
             try {
               await this.signer.handshake({ method: 'handshake' }); // exchange session keys
               const result = await this.signer.request(args); // send diffie-hellman encrypted request

--- a/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
+++ b/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
@@ -19,6 +19,7 @@ import { hexStringFromNumber } from ':core/type/util.js';
 import { Signer } from ':sign/base-account/Signer.js';
 import { initSubAccountConfig } from ':sign/base-account/utils.js';
 import { correlationIds } from ':store/correlation-ids/store.js';
+import { externalCorrelationIds } from ':store/external-correlation-id/store.js';
 import { store } from ':store/store.js';
 import { checkErrorForInvalidRequestArgs, fetchRPCRequest } from ':util/provider.js';
 
@@ -101,12 +102,6 @@ export class BaseAccountProvider extends ProviderEventEmitter implements Provide
           }
           case 'wallet_sendCalls':
           case 'wallet_sign': {
-            // Extract and store paymentLinkId if present in the request params
-            const paymentLinkId = (args.params as any)?.[0]?.paymentLinkId;
-            if (paymentLinkId) {
-              store.config.set({ paymentLinkId });
-            }
-
             try {
               await this.signer.handshake({ method: 'handshake' }); // exchange session keys
               const result = await this.signer.request(args); // send diffie-hellman encrypted request
@@ -151,6 +146,7 @@ export class BaseAccountProvider extends ProviderEventEmitter implements Provide
   async disconnect() {
     await this.signer.cleanup();
     correlationIds.clear();
+    externalCorrelationIds.clear();
     this.emit('disconnect', standardErrors.provider.disconnected('User initiated disconnection'));
   }
 

--- a/packages/account-sdk/src/store/external-correlation-id/store.test.ts
+++ b/packages/account-sdk/src/store/external-correlation-id/store.test.ts
@@ -19,10 +19,10 @@ describe('externalCorrelationIds', () => {
   it('should update existing external correlation ID', () => {
     const firstId = 'first-id';
     const secondId = 'second-id';
-    
+
     externalCorrelationIds.set(firstId);
     expect(externalCorrelationIds.get()).toBe(firstId);
-    
+
     externalCorrelationIds.set(secondId);
     expect(externalCorrelationIds.get()).toBe(secondId);
   });
@@ -31,7 +31,7 @@ describe('externalCorrelationIds', () => {
     const testId = 'test-id';
     externalCorrelationIds.set(testId);
     expect(externalCorrelationIds.get()).toBe(testId);
-    
+
     externalCorrelationIds.clear();
     expect(externalCorrelationIds.get()).toBe(null);
   });

--- a/packages/account-sdk/src/store/external-correlation-id/store.test.ts
+++ b/packages/account-sdk/src/store/external-correlation-id/store.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { externalCorrelationIds } from './store.js';
+
+describe('externalCorrelationIds', () => {
+  beforeEach(() => {
+    externalCorrelationIds.clear();
+  });
+
+  it('should start with null value', () => {
+    expect(externalCorrelationIds.get()).toBe(null);
+  });
+
+  it('should set and get external correlation ID', () => {
+    const testId = 'test-external-correlation-id-123';
+    externalCorrelationIds.set(testId);
+    expect(externalCorrelationIds.get()).toBe(testId);
+  });
+
+  it('should update existing external correlation ID', () => {
+    const firstId = 'first-id';
+    const secondId = 'second-id';
+    
+    externalCorrelationIds.set(firstId);
+    expect(externalCorrelationIds.get()).toBe(firstId);
+    
+    externalCorrelationIds.set(secondId);
+    expect(externalCorrelationIds.get()).toBe(secondId);
+  });
+
+  it('should clear external correlation ID', () => {
+    const testId = 'test-id';
+    externalCorrelationIds.set(testId);
+    expect(externalCorrelationIds.get()).toBe(testId);
+    
+    externalCorrelationIds.clear();
+    expect(externalCorrelationIds.get()).toBe(null);
+  });
+});

--- a/packages/account-sdk/src/store/external-correlation-id/store.ts
+++ b/packages/account-sdk/src/store/external-correlation-id/store.ts
@@ -1,0 +1,21 @@
+import { createStore } from 'zustand/vanilla';
+
+type ExternalCorrelationIdState = {
+  externalCorrelationId: string | null;
+};
+
+const externalCorrelationIdStore = createStore<ExternalCorrelationIdState>(() => ({
+  externalCorrelationId: null,
+}));
+
+export const externalCorrelationIds = {
+  get: (): string | null => {
+    return externalCorrelationIdStore.getState().externalCorrelationId;
+  },
+  set: (externalCorrelationId: string) => {
+    externalCorrelationIdStore.setState({ externalCorrelationId });
+  },
+  clear: () => {
+    externalCorrelationIdStore.setState({ externalCorrelationId: null });
+  },
+};

--- a/packages/account-sdk/src/store/store.ts
+++ b/packages/account-sdk/src/store/store.ts
@@ -42,7 +42,7 @@ type Config = {
   version: string;
   deviceId?: string;
   paymasterUrls?: Record<number, string>;
-  paymentLinkId?: string;
+  externalCorrelationId?: string;
 };
 
 type ChainSlice = {

--- a/packages/account-sdk/src/store/store.ts
+++ b/packages/account-sdk/src/store/store.ts
@@ -42,6 +42,7 @@ type Config = {
   version: string;
   deviceId?: string;
   paymasterUrls?: Record<number, string>;
+  paymentLinkId?: string;
 };
 
 type ChainSlice = {

--- a/packages/account-sdk/src/util/web.test.ts
+++ b/packages/account-sdk/src/util/web.test.ts
@@ -2,6 +2,7 @@ import { waitFor } from '@testing-library/preact';
 import { Mock, vi } from 'vitest';
 
 import { PACKAGE_NAME, PACKAGE_VERSION } from ':core/constants.js';
+import { store } from ':store/store.js';
 import { getCrossOriginOpenerPolicy } from './checkCrossOriginOpenerPolicy.js';
 import { closePopup, openPopup } from './web.js';
 
@@ -83,6 +84,25 @@ describe('PopupManager', () => {
 
     const paramCount = url.searchParams.toString().split('&').length;
     expect(paramCount).toBe(4);
+  });
+
+  it('should include paymentLinkId in URL when present in store config', async () => {
+    const paymentLinkId = 'payment_link_12345';
+    (store.config.get as Mock).mockReturnValue({ 
+      metadata: { appName: 'Test App' },
+      paymentLinkId 
+    });
+
+    const url = new URL('https://example.com');
+    (window.open as Mock).mockReturnValue({ focus: vi.fn() });
+
+    await openPopup(url);
+
+    expect(url.searchParams.get('paymentLinkId')).toBe(paymentLinkId);
+    expect(url.searchParams.get('sdkName')).toBe(PACKAGE_NAME);
+    expect(url.searchParams.get('sdkVersion')).toBe(PACKAGE_VERSION);
+    expect(url.searchParams.get('origin')).toBe(mockOrigin);
+    expect(url.searchParams.get('coop')).toBe('null');
   });
 
   it('should show snackbar with retry button when popup is blocked and retry successfully', async () => {

--- a/packages/account-sdk/src/util/web.test.ts
+++ b/packages/account-sdk/src/util/web.test.ts
@@ -88,9 +88,9 @@ describe('PopupManager', () => {
 
   it('should include paymentLinkId in URL when present in store config', async () => {
     const paymentLinkId = 'payment_link_12345';
-    (store.config.get as Mock).mockReturnValue({ 
+    (store.config.get as Mock).mockReturnValue({
       metadata: { appName: 'Test App' },
-      paymentLinkId 
+      paymentLinkId,
     });
 
     const url = new URL('https://example.com');

--- a/packages/account-sdk/src/util/web.test.ts
+++ b/packages/account-sdk/src/util/web.test.ts
@@ -86,11 +86,11 @@ describe('PopupManager', () => {
     expect(paramCount).toBe(4);
   });
 
-  it('should include paymentLinkId in URL when present in store config', async () => {
-    const paymentLinkId = 'payment_link_12345';
+  it('should include externalCorrelationId in URL when present in store config', async () => {
+    const externalCorrelationId = 'external_correlation_id_12345';
     (store.config.get as Mock).mockReturnValue({
       metadata: { appName: 'Test App' },
-      paymentLinkId,
+      externalCorrelationId,
     });
 
     const url = new URL('https://example.com');
@@ -98,7 +98,7 @@ describe('PopupManager', () => {
 
     await openPopup(url);
 
-    expect(url.searchParams.get('paymentLinkId')).toBe(paymentLinkId);
+    expect(url.searchParams.get('externalCorrelationId')).toBe(externalCorrelationId);
     expect(url.searchParams.get('sdkName')).toBe(PACKAGE_NAME);
     expect(url.searchParams.get('sdkVersion')).toBe(PACKAGE_VERSION);
     expect(url.searchParams.get('origin')).toBe(mockOrigin);

--- a/packages/account-sdk/src/util/web.ts
+++ b/packages/account-sdk/src/util/web.ts
@@ -1,6 +1,7 @@
 import { PACKAGE_NAME, PACKAGE_VERSION } from ':core/constants.js';
 import { standardErrors } from ':core/error/errors.js';
 import { logDialogActionClicked, logDialogShown } from ':core/telemetry/events/dialog.js';
+import { externalCorrelationIds } from ':store/external-correlation-id/store.js';
 import { store } from ':store/store.js';
 import { initDialog } from '../ui/Dialog/index.js';
 import { getCrossOriginOpenerPolicy } from './checkCrossOriginOpenerPolicy.js';
@@ -50,13 +51,13 @@ export function closePopup(popup: Window | null) {
 }
 
 function appendAppInfoQueryParams(url: URL) {
-  const config = store.config.get();
+  const externalCorrelationId = externalCorrelationIds.get();
   const params = {
     sdkName: PACKAGE_NAME,
     sdkVersion: PACKAGE_VERSION,
     origin: window.location.origin,
     coop: getCrossOriginOpenerPolicy(),
-    ...(config.paymentLinkId && { paymentLinkId: config.paymentLinkId }),
+    ...(externalCorrelationId && { externalCorrelationId }),
   };
 
   for (const [key, value] of Object.entries(params)) {

--- a/packages/account-sdk/src/util/web.ts
+++ b/packages/account-sdk/src/util/web.ts
@@ -50,11 +50,13 @@ export function closePopup(popup: Window | null) {
 }
 
 function appendAppInfoQueryParams(url: URL) {
+  const config = store.config.get();
   const params = {
     sdkName: PACKAGE_NAME,
     sdkVersion: PACKAGE_VERSION,
     origin: window.location.origin,
     coop: getCrossOriginOpenerPolicy(),
+    ...(config.paymentLinkId && { paymentLinkId: config.paymentLinkId }),
   };
 
   for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
### _Summary_

Adds support for setting an external correlation ID, which gets automatically included in popup URLs as a query parameter.

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

- Unit tests

<!--
  Verify changes. Include relevant screenshots/videos
-->
