### PR TITLE
docs: fix typo: "Base Account"

### DIFF
--- a/packages/account-sdk/README.md
+++ b/packages/account-sdk/README.md
@@ -127,7 +127,7 @@
 
 ## Script Tag Usage
 
-Base Accunt can be used directly in HTML pages via a script tag, without any build tools:
+Base Account can be used directly in HTML pages via a script tag, without any build tools:
 
 ```html
 <!-- Via unpkg -->


### PR DESCRIPTION
### *Summary*

fixed a typo: "Base Accunt" to "Base Account".

### *How did you test your changes?*

checked the UI where the label appears to confirm it now displays correctly.
