### PR TITLE
Fix TypeScript export resolution for payment and spend-permission modules

### DIFF
--- a/packages/account-sdk/package.json
+++ b/packages/account-sdk/package.json
@@ -32,6 +32,7 @@
       "require": "./dist/interface/payment/index.node.js"
     },
     "./payment": {
+      "types": "./dist/interface/payment/index.d.ts",
       "browser": {
         "types": "./dist/interface/payment/index.d.ts",
         "import": "./dist/interface/payment/index.js",
@@ -54,6 +55,7 @@
       "require": "./dist/interface/public-utilities/spend-permission/index.node.js"
     },
     "./spend-permission": {
+      "types": "./dist/interface/public-utilities/spend-permission/index.d.ts",
       "browser": {
         "types": "./dist/interface/public-utilities/spend-permission/index.d.ts",
         "import": "./dist/interface/public-utilities/spend-permission/index.js",


### PR DESCRIPTION
### _Summary_

Added top-level `types` export field for `payment` and `spend-permission` module exports in package.json. This ensures TypeScript correctly resolves type definitions when importing these modules, improving developer experience and preventing potential type resolution issues.

The change adds explicit `types` field at the root level of each export configuration, ensuring TypeScript can properly locate type definitions regardless of the runtime environment (browser/node).

### _How did you test your changes?_

- Verified all existing tests pass with `yarn test`
- All CI checks pass successfully

Manual testing:
- Verified that TypeScript correctly resolves types when importing from `@base-org/account/payment` and `@base-org/account/spend-permission`
