### PR TITLE
refactor: sub accounts mode param

### DIFF
--- a/examples/testapp/src/context/EIP1193ProviderContextProvider.test.tsx
+++ b/examples/testapp/src/context/EIP1193ProviderContextProvider.test.tsx
@@ -49,7 +49,7 @@ describe('EIP1193ProviderContextProvider', () => {
       setScwUrlAndSave: vi.fn(),
       setConfig: vi.fn(),
       subAccountsConfig: {
-        enableAutoSubAccounts: true,
+        mode: 'auto',
       },
       setSubAccountsConfig: vi.fn(),
     });
@@ -88,7 +88,7 @@ describe('EIP1193ProviderContextProvider', () => {
         walletUrl: 'https://keys-dev.coinbase.com/connect',
       },
       subAccounts: {
-        enableAutoSubAccounts: true,
+        mode: 'auto',
       },
     });
     expect(screen.getByTestId('sdk-exists')).toBeTruthy();
@@ -103,7 +103,7 @@ describe('EIP1193ProviderContextProvider', () => {
       scwUrl: 'https://keys-dev.coinbase.com/connect',
       config: { attribution: { dataSuffix: '0xtestattribution' } },
       subAccountsConfig: {
-        enableAutoSubAccounts: true,
+        mode: 'auto',
       },
       setSDKVersion: vi.fn(),
       setScwUrlAndSave: vi.fn(),
@@ -125,7 +125,7 @@ describe('EIP1193ProviderContextProvider', () => {
         walletUrl: 'https://keys-dev.coinbase.com/connect',
       },
       subAccounts: {
-        enableAutoSubAccounts: true,
+        mode: 'auto',
       },
     });
   });

--- a/examples/testapp/src/pages/auto-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/auto-sub-account/index.page.tsx
@@ -354,7 +354,7 @@ export default function AutoSubAccount() {
   return (
     <Container mb={16}>
       <Text fontSize="3xl" fontWeight="bold" mb={4}>
-        Auto Sub Account
+        Sub Account
       </Text>
       <VStack w="full" spacing={4}>
         <Box w="full" textAlign="left" fontSize="lg" fontWeight="bold">
@@ -370,19 +370,19 @@ export default function AutoSubAccount() {
           </RadioGroup>
         </FormControl>
         <FormControl>
-          <FormLabel>Auto Sub-Accounts</FormLabel>
+          <FormLabel>Sub-Account Mode</FormLabel>
           <RadioGroup
-            value={(subAccountsConfig?.enableAutoSubAccounts || false).toString()}
+            value={subAccountsConfig?.mode ?? 'manual'}
             onChange={(value) =>
               setSubAccountsConfig((prev) => ({
                 ...prev,
-                enableAutoSubAccounts: value === 'true',
+                mode: value as 'auto' | 'manual',
               }))
             }
           >
             <Stack direction="row">
-              <Radio value="true">Enabled</Radio>
-              <Radio value="false">Disabled</Radio>
+              <Radio value="manual">Manual</Radio>
+              <Radio value="auto">Auto</Radio>
             </Stack>
           </RadioGroup>
         </FormControl>

--- a/packages/account-sdk/src/core/provider/interface.ts
+++ b/packages/account-sdk/src/core/provider/interface.ts
@@ -86,8 +86,8 @@ export type Preference = {
 } & Record<string, unknown>;
 
 export type SubAccountOptions = {
-  /* Automatically create a subaccount for the user and use it for all transactions. */
-  enableAutoSubAccounts?: boolean;
+  /* Sub-account usage mode. When 'auto', automatically create/use a subaccount for all transactions. */
+  mode?: 'auto' | 'manual';
   /**
    * @returns The owner account that will be used to sign the subaccount transactions.
    */

--- a/packages/account-sdk/src/core/telemetry/events/scw-signer.ts
+++ b/packages/account-sdk/src/core/telemetry/events/scw-signer.ts
@@ -15,7 +15,7 @@ export const logHandshakeStarted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -38,7 +38,7 @@ export const logHandshakeError = ({
       method,
       correlationId,
       errorMessage,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -58,7 +58,7 @@ export const logHandshakeCompleted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -78,7 +78,7 @@ export const logRequestStarted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -101,7 +101,7 @@ export const logRequestError = ({
       method,
       correlationId,
       errorMessage,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -121,7 +121,7 @@ export const logRequestCompleted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );

--- a/packages/account-sdk/src/core/telemetry/events/scw-sub-account.ts
+++ b/packages/account-sdk/src/core/telemetry/events/scw-sub-account.ts
@@ -15,7 +15,7 @@ export const logSubAccountRequestStarted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -35,7 +35,7 @@ export const logSubAccountRequestCompleted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -58,7 +58,7 @@ export const logSubAccountRequestError = ({
       method,
       correlationId,
       errorMessage,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -78,7 +78,7 @@ export const logAddOwnerStarted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -98,7 +98,7 @@ export const logAddOwnerCompleted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -121,7 +121,7 @@ export const logAddOwnerError = ({
       method,
       correlationId,
       errorMessage,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -141,7 +141,7 @@ export const logInsufficientBalanceErrorHandlingStarted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -161,7 +161,7 @@ export const logInsufficientBalanceErrorHandlingCompleted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );
@@ -184,7 +184,7 @@ export const logInsufficientBalanceErrorHandlingError = ({
       method,
       correlationId,
       errorMessage,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountMode: store.subAccountsConfig.get()?.mode,
     },
     AnalyticsEventImportance.high
   );

--- a/packages/account-sdk/src/core/telemetry/logEvent.ts
+++ b/packages/account-sdk/src/core/telemetry/logEvent.ts
@@ -63,7 +63,7 @@ type CCAEventData = {
   errorMessage?: string;
   dialogContext?: string;
   dialogAction?: string;
-  enableAutoSubAccounts?: boolean;
+  subAccountMode?: 'auto' | 'manual';
   // Payment-specific attributes
   amount?: string;
   testnet?: boolean;

--- a/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.test.ts
+++ b/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.test.ts
@@ -116,9 +116,9 @@ describe('Ephemeral methods', () => {
 });
 
 describe('Auto sub account', () => {
-  it('call handshake without method when enableAutoSubAccounts is true', async () => {
+  it("call handshake without method when sub-account mode is 'auto'", async () => {
     vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
-      enableAutoSubAccounts: true,
+      mode: 'auto',
     });
 
     await provider.request({ method: 'eth_requestAccounts' });

--- a/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.test.ts
+++ b/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.test.ts
@@ -147,8 +147,7 @@ describe('createProvider', () => {
       const params: CreateProviderOptions = {
         subAccounts: {
           toOwnerAccount: mockToOwnerAccount,
-          // @ts-expect-error - enableAutoSubAccounts is not officially supported yet
-          enableAutoSubAccounts: true,
+          mode: 'auto',
         },
       };
 
@@ -157,7 +156,7 @@ describe('createProvider', () => {
       expect(mockValidateSubAccount).toHaveBeenCalledWith(mockToOwnerAccount);
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: mockToOwnerAccount,
-        enableAutoSubAccounts: true,
+        mode: 'auto',
         unstable_enableAutoSpendPermissions: true,
       });
     });
@@ -165,8 +164,7 @@ describe('createProvider', () => {
     it('should handle partial sub-account configuration', () => {
       const params: CreateProviderOptions = {
         subAccounts: {
-          // @ts-expect-error - enableAutoSubAccounts is not officially supported yet
-          enableAutoSubAccounts: true,
+          mode: 'auto',
         },
       };
 
@@ -175,7 +173,7 @@ describe('createProvider', () => {
       expect(mockValidateSubAccount).not.toHaveBeenCalled();
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: undefined,
-        enableAutoSubAccounts: true,
+        mode: 'auto',
         unstable_enableAutoSpendPermissions: true,
       });
     });
@@ -189,7 +187,7 @@ describe('createProvider', () => {
 
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: undefined,
-        enableAutoSubAccounts: undefined,
+        mode: 'manual',
         unstable_enableAutoSpendPermissions: true,
       });
     });
@@ -199,8 +197,7 @@ describe('createProvider', () => {
       const params: CreateProviderOptions = {
         subAccounts: {
           toOwnerAccount: mockToOwnerAccount,
-          // @ts-expect-error - enableAutoSubAccounts is not officially supported yet
-          enableAutoSubAccounts: true,
+          mode: 'auto',
           unstable_enableAutoSpendPermissions: true,
         },
       };
@@ -210,7 +207,7 @@ describe('createProvider', () => {
       expect(mockValidateSubAccount).toHaveBeenCalledWith(mockToOwnerAccount);
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: mockToOwnerAccount,
-        enableAutoSubAccounts: true,
+        mode: 'auto',
         unstable_enableAutoSpendPermissions: true,
       });
     });
@@ -227,7 +224,7 @@ describe('createProvider', () => {
 
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: mockToOwnerAccount,
-        enableAutoSubAccounts: undefined,
+        mode: 'manual',
         unstable_enableAutoSpendPermissions: true,
       });
     });
@@ -245,7 +242,7 @@ describe('createProvider', () => {
 
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: mockToOwnerAccount,
-        enableAutoSubAccounts: undefined,
+        mode: 'manual',
         unstable_enableAutoSpendPermissions: true,
       });
     });
@@ -390,8 +387,7 @@ describe('createProvider', () => {
         },
         subAccounts: {
           toOwnerAccount: mockToOwnerAccount,
-          // @ts-expect-error - enableAutoSubAccounts is not officially supported yet
-          enableAutoSubAccounts: true,
+          mode: 'auto',
         },
         paymasterUrls: {
           1: 'https://paymaster.example.com',
@@ -404,7 +400,7 @@ describe('createProvider', () => {
       expect(mockValidateSubAccount).toHaveBeenCalledWith(mockToOwnerAccount);
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: mockToOwnerAccount,
-        enableAutoSubAccounts: true,
+        mode: 'auto',
         unstable_enableAutoSpendPermissions: true,
       });
 

--- a/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
+++ b/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
@@ -49,7 +49,7 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
 
   store.subAccountsConfig.set({
     toOwnerAccount: params.subAccounts?.toOwnerAccount,
-    enableAutoSubAccounts: params.subAccounts?.enableAutoSubAccounts,
+    mode: params.subAccounts?.mode ?? 'manual',
     unstable_enableAutoSpendPermissions:
       params.subAccounts?.unstable_enableAutoSpendPermissions ?? true,
   });

--- a/packages/account-sdk/src/sign/base-account/Signer.test.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.test.ts
@@ -531,7 +531,7 @@ describe('Signer', () => {
       vi.restoreAllMocks();
     });
 
-    it('should return accounts in correct order based on enableAutoSubAccounts', async () => {
+    it('should return accounts in correct order based on sub-account mode', async () => {
       // Set up the signer with a global account
       signer['accounts'] = [globalAccountAddress];
       signer['chain'] = { id: 1, rpcUrl: 'https://eth-rpc.example.com/1' };
@@ -543,23 +543,23 @@ describe('Signer', () => {
         factoryData: '0x',
       });
 
-      // Test with enableAutoSubAccounts = false
+      // Test with mode = 'manual'
       const configSpy = vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
-        enableAutoSubAccounts: false,
+        mode: 'manual',
       });
 
       let accounts = await signer.request({ method: 'eth_accounts' });
       expect(accounts).toEqual([globalAccountAddress, subAccountAddress]);
 
-      // Test with enableAutoSubAccounts = true
+      // Test with mode = 'auto'
       configSpy.mockReturnValue({
-        enableAutoSubAccounts: true,
+        mode: 'auto',
       });
 
       accounts = await signer.request({ method: 'eth_accounts' });
       expect(accounts).toEqual([subAccountAddress, globalAccountAddress]);
 
-      // Test when enableAutoSubAccounts is undefined (should default to false behavior)
+      // Test when mode is undefined (should default to manual behavior)
       configSpy.mockReturnValue(undefined);
 
       accounts = await signer.request({ method: 'eth_accounts' });
@@ -705,7 +705,7 @@ describe('Signer', () => {
         factoryData: '0x',
       });
 
-      // eth_accounts should return [globalAccount, subAccount] when enableAutoSubAccounts is not true
+      // eth_accounts should return [globalAccount, subAccount] when mode is not 'auto'
       const accounts = await signer.request({ method: 'eth_accounts' });
 
       expect(accounts).toEqual([globalAccountAddress, subAccountAddress]);
@@ -771,7 +771,7 @@ describe('Signer', () => {
         factoryData: '0x',
       });
 
-      // eth_accounts should return [globalAccount, subAccount] when enableAutoSubAccounts is not true
+      // eth_accounts should return [globalAccount, subAccount] when mode is not 'auto'
       const accounts = await signer.request({ method: 'eth_accounts' });
       expect(accounts).toEqual([globalAccountAddress, subAccountAddress]);
     });
@@ -972,12 +972,12 @@ describe('Signer', () => {
       });
     });
 
-    it('should always return sub account first when enableAutoSubAccounts is true', async () => {
+    it("should always return sub account first when mode is 'auto'", async () => {
       expect(signer['accounts']).toEqual([]);
 
       // Enable auto sub accounts
       vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
-        enableAutoSubAccounts: true,
+        mode: 'auto',
       });
 
       const mockRequest: RequestArguments = {
@@ -1021,7 +1021,7 @@ describe('Signer', () => {
         factoryData: '0x',
       });
 
-      // When enableAutoSubAccounts is true, sub account should be first
+      // When mode is 'auto', sub account should be first
       const accounts = await signer.request({ method: 'eth_accounts' });
       expect(accounts).toEqual([subAccountAddress, globalAccountAddress]);
 
@@ -1192,12 +1192,12 @@ describe('Signer', () => {
       expect(accounts).toEqual([globalAccountAddress, subAccountAddress]);
     });
 
-    it('should always return sub account first when enableAutoSubAccounts is true', async () => {
+    it("should always return sub account first when mode is 'auto'", async () => {
       await signer.cleanup();
 
       // Enable auto sub accounts
       vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
-        enableAutoSubAccounts: true,
+        mode: 'auto',
       });
 
       const mockRequest: RequestArguments = {
@@ -1257,11 +1257,11 @@ describe('Signer', () => {
         ],
       });
 
-      // wallet_addSubAccount now respects enableAutoSubAccounts, so sub account should be first
+      // wallet_addSubAccount now respects sub account mode, so sub account should be first
       const accounts = await signer.request({ method: 'eth_accounts' });
       expect(accounts).toEqual([subAccountAddress, globalAccountAddress]);
 
-      // However, eth_requestAccounts will reorder based on enableAutoSubAccounts
+      // However, eth_requestAccounts will reorder based on sub account mode
       const requestedAccounts = await signer.request({ method: 'eth_requestAccounts' });
       expect(requestedAccounts).toEqual([subAccountAddress, globalAccountAddress]);
     });
@@ -1279,7 +1279,7 @@ describe('Signer', () => {
       });
 
       vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
-        enableAutoSubAccounts: true,
+        mode: 'auto',
       });
 
       (decryptContent as Mock).mockResolvedValueOnce({
@@ -1904,7 +1904,7 @@ describe('Signer', () => {
       });
 
       vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
-        enableAutoSubAccounts: true,
+        mode: 'auto',
         toOwnerAccount: async () => ({
           account: {
             type: 'local' as const,
@@ -2198,7 +2198,7 @@ describe('Signer', () => {
     it('should skip spend permission check when unstable_enableAutoSpendPermissions is false', async () => {
       // Mock the config with unstable_enableAutoSpendPermissions disabled
       vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
-        enableAutoSubAccounts: true,
+        mode: 'auto',
         unstable_enableAutoSpendPermissions: false,
         toOwnerAccount: async () => ({
           account: {
@@ -2249,7 +2249,7 @@ describe('Signer', () => {
     it('should skip insufficient balance error handling when unstable_enableAutoSpendPermissions is false', async () => {
       // Mock the config with unstable_enableAutoSpendPermissions disabled
       vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
-        enableAutoSubAccounts: true,
+        mode: 'auto',
         unstable_enableAutoSpendPermissions: false,
         toOwnerAccount: async () => ({
           account: {
@@ -2328,7 +2328,7 @@ describe('Signer', () => {
     it('should still route through global account and handle insufficient balance errors when unstable_enableAutoSpendPermissions is true', async () => {
       // Mock the config with unstable_enableAutoSpendPermissions enabled (default)
       vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
-        enableAutoSubAccounts: true,
+        mode: 'auto',
         unstable_enableAutoSpendPermissions: true,
         toOwnerAccount: async () => ({
           account: {
@@ -2374,7 +2374,7 @@ describe('Signer', () => {
     it('should handle insufficient balance errors when unstable_enableAutoSpendPermissions is undefined (default behavior)', async () => {
       // Mock the config without unstable_enableAutoSpendPermissions (undefined)
       vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
-        enableAutoSubAccounts: true,
+        mode: 'auto',
         toOwnerAccount: async () => ({
           account: {
             type: 'local' as const,

--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -218,9 +218,10 @@ export class Signer {
         if (subAccount?.address) {
           // if auto sub accounts are enabled and we have a sub account, we need to return it as a top level account
           // otherwise, we just append it to the accounts array
-          this.accounts = subAccountsConfig?.enableAutoSubAccounts
-            ? prependWithoutDuplicates(this.accounts, subAccount.address)
-            : appendWithoutDuplicates(this.accounts, subAccount.address);
+          this.accounts =
+            subAccountsConfig?.mode === 'auto'
+              ? prependWithoutDuplicates(this.accounts, subAccount.address)
+              : appendWithoutDuplicates(this.accounts, subAccount.address);
         }
 
         this.callback?.('connect', { chainId: numberToHex(this.chain.id) });
@@ -389,9 +390,10 @@ export class Signer {
 
         if (subAccount?.address) {
           // Sub account should be returned as a top level account if auto sub accounts are enabled
-          this.accounts = subAccountsConfig?.enableAutoSubAccounts
-            ? prependWithoutDuplicates(this.accounts, subAccount.address)
-            : appendWithoutDuplicates(this.accounts, subAccount.address);
+          this.accounts =
+            subAccountsConfig?.mode === 'auto'
+              ? prependWithoutDuplicates(this.accounts, subAccount.address)
+              : appendWithoutDuplicates(this.accounts, subAccount.address);
         }
 
         const spendPermissions = response?.accounts?.[0].capabilities?.spendPermissions;
@@ -408,9 +410,10 @@ export class Signer {
         const subAccount = result.value;
         store.subAccounts.set(subAccount);
         const subAccountsConfig = store.subAccountsConfig.get();
-        this.accounts = subAccountsConfig?.enableAutoSubAccounts
-          ? prependWithoutDuplicates(this.accounts, subAccount.address)
-          : appendWithoutDuplicates(this.accounts, subAccount.address);
+        this.accounts =
+          subAccountsConfig?.mode === 'auto'
+            ? prependWithoutDuplicates(this.accounts, subAccount.address)
+            : appendWithoutDuplicates(this.accounts, subAccount.address);
         this.callback?.('accountsChanged', this.accounts);
         break;
       }
@@ -601,9 +604,10 @@ export class Signer {
     const subAccount = state.subAccount;
     const subAccountsConfig = store.subAccountsConfig.get();
     if (subAccount?.address) {
-      this.accounts = subAccountsConfig?.enableAutoSubAccounts
-        ? prependWithoutDuplicates(this.accounts, subAccount.address)
-        : appendWithoutDuplicates(this.accounts, subAccount.address);
+      this.accounts =
+        subAccountsConfig?.mode === 'auto'
+          ? prependWithoutDuplicates(this.accounts, subAccount.address)
+          : appendWithoutDuplicates(this.accounts, subAccount.address);
       this.callback?.('accountsChanged', this.accounts);
       return subAccount;
     }

--- a/packages/account-sdk/src/sign/base-account/utils.test.ts
+++ b/packages/account-sdk/src/sign/base-account/utils.test.ts
@@ -271,7 +271,7 @@ describe('injectRequestCapabilities', () => {
 describe('initSubAccountConfig', () => {
   it('should initialize the sub account config', async () => {
     store.subAccountsConfig.set({
-      enableAutoSubAccounts: true,
+      mode: 'auto',
       toOwnerAccount: vi.fn().mockResolvedValue({
         account: {
           address: '0x123',

--- a/packages/account-sdk/src/sign/base-account/utils.ts
+++ b/packages/account-sdk/src/sign/base-account/utils.ts
@@ -148,7 +148,7 @@ export async function initSubAccountConfig() {
 
   const capabilities: WalletConnectRequest['params'][0]['capabilities'] = {};
 
-  if (config.enableAutoSubAccounts) {
+  if (config.mode === 'auto') {
     // Get the owner account
     const { account: owner } = config.toOwnerAccount
       ? await config.toOwnerAccount()


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

https://linear.app/coinbase/issue/BA-2882/expose-enableautosubaccounts-again

- Replaced `enableAutoSubAccounts` with `mode: 'auto' | 'manual'` across types, SDK init, logic, telemetry, example UI, and tests.
- Defaulted the mode to `'manual'`.
- Grepped and updated all usages.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

Unit tests, manual tests
