### PR TITLE
fix: type mismatch for `get` and `set` methods

### DIFF
--- a/examples/testapp/src/theme/index.ts
+++ b/examples/testapp/src/theme/index.ts
@@ -33,7 +33,7 @@ export const theme = extendTheme({
  * playground will default to the current system color mode.
  */
 export const systemStorageManager = {
-  get: () => undefined,
-  set: () => {},
+  get: () => null,
+  set: (_value: string) => {},
   type: 'localStorage' as const,
 };


### PR DESCRIPTION
### _Summary_

Fixed type mismatches for `get` and `set` methods:

* `get` now returns `null` instead of `undefined` to match `string | null`.
* `set` now accepts a single `string` argument, even if the body is empty.
  These changes prevent TypeScript errors and ensure the API aligns with its type definitions.

### _How did you test your changes?_

TypeScript compilation passes without errors. Verified that `get` and `set` calls behave as expected in the consuming code.

