### PR TITLE
Add version export to SDK

### DIFF
--- a/packages/account-sdk/src/browser-entry.ts
+++ b/packages/account-sdk/src/browser-entry.ts
@@ -3,6 +3,7 @@
  * This file exposes the account interface to the global window object
  */
 
+import { PACKAGE_VERSION } from './core/constants.js';
 import { createBaseAccountSDK } from './interface/builder/core/createBaseAccountSDK.js';
 import { base } from './interface/payment/base.js';
 import { CHAIN_IDS, TOKENS } from './interface/payment/constants.js';
@@ -24,6 +25,9 @@ import type {
 if (typeof window !== 'undefined') {
   (window as any).base = base;
   (window as any).createBaseAccountSDK = createBaseAccountSDK;
+  (window as any).BaseAccountSDK = {
+    VERSION: PACKAGE_VERSION,
+  };
 }
 
 // Export for module usage
@@ -32,6 +36,7 @@ export type {
   Preference,
   ProviderInterface,
 } from ':core/provider/interface.js';
+export { PACKAGE_VERSION as VERSION } from './core/constants.js';
 export { createBaseAccountSDK } from './interface/builder/core/createBaseAccountSDK.js';
 export { getCryptoKeyAccount, removeCryptoKey } from './kms/crypto-key/index.js';
 export { base, CHAIN_IDS, getPaymentStatus, pay, subscribe, TOKENS };

--- a/packages/account-sdk/src/index.ts
+++ b/packages/account-sdk/src/index.ts
@@ -5,6 +5,8 @@ export { createBaseAccountSDK } from './interface/builder/core/createBaseAccount
 
 export { getCryptoKeyAccount, removeCryptoKey } from './kms/crypto-key/index.js';
 
+export { PACKAGE_VERSION as VERSION } from './core/constants.js';
+
 // Payment interface exports
 export {
   CHAIN_IDS,


### PR DESCRIPTION
## What changed? Why?

the version is now exposed on the global window.BaseAccountSDK.VERSION property.

## How was this tested?
Manually tested locally


## How can reviewers manually test these changes?


## Demo/screenshots


