### PR TITLE
Fix Permission Status API

### DIFF
--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getPermissionStatus.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getPermissionStatus.test.ts
@@ -1,7 +1,7 @@
 import { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
 import {
-  spendPermissionManagerAbi,
-  spendPermissionManagerAddress,
+    spendPermissionManagerAbi,
+    spendPermissionManagerAddress,
 } from ':sign/base-account/utils/constants.js';
 import { getClient } from ':store/chain-clients/utils.js';
 import { PublicClient, createPublicClient, http } from 'viem';
@@ -110,6 +110,7 @@ describe('getPermissionStatus - browser + node', () => {
         isRevoked: false,
         isExpired: false, // current time (1234567890) < end time (1234654290)
         isActive: true, // not revoked and not expired
+        currentPeriod: mockCurrentPeriod,
       });
 
       expect(getClient).toHaveBeenCalledWith(8453);
@@ -157,6 +158,7 @@ describe('getPermissionStatus - browser + node', () => {
       expect(result.isRevoked).toBe(false);
       expect(result.isExpired).toBe(false);
       expect(result.isActive).toBe(true);
+      expect(result.currentPeriod).toEqual(mockCurrentPeriod);
 
       // Test with node environment
       (getClient as Mock).mockReturnValue(null);
@@ -196,6 +198,7 @@ describe('getPermissionStatus - browser + node', () => {
       expect(result.isRevoked).toBe(true);
       expect(result.isExpired).toBe(false);
       expect(result.isActive).toBe(false);
+      expect(result.currentPeriod).toEqual(mockCurrentPeriod);
 
       // Test with node environment
       (getClient as Mock).mockReturnValue(null);
@@ -235,6 +238,7 @@ describe('getPermissionStatus - browser + node', () => {
       expect(result.isRevoked).toBe(false);
       expect(result.isExpired).toBe(true);
       expect(result.isActive).toBe(false);
+      expect(result.currentPeriod).toEqual(mockCurrentPeriod);
 
       // Test with node environment
       (getClient as Mock).mockReturnValue(null);
@@ -501,6 +505,7 @@ describe('getPermissionStatus - browser + node', () => {
       const result = await getPermissionStatus(permissionWithZeroAllowance);
 
       expect(result.remainingSpend).toBe(BigInt(0));
+      expect(result.currentPeriod).toEqual(mockCurrentPeriod);
 
       // Test with node environment
       (getClient as Mock).mockReturnValue(null);
@@ -543,6 +548,7 @@ describe('getPermissionStatus - browser + node', () => {
       expect(result.remainingSpend).toBe(
         BigInt('999999999999999999999999999999') - BigInt('1000000000000000000')
       );
+      expect(result.currentPeriod).toEqual(mockCurrentPeriod);
 
       // Test with node environment
       (getClient as Mock).mockReturnValue(null);
@@ -575,6 +581,7 @@ describe('getPermissionStatus - browser + node', () => {
       const result = await getPermissionStatus(mockSpendPermission);
 
       expect(result.nextPeriodStart).toEqual(new Date(2147483648 * 1000));
+      expect(result.currentPeriod).toEqual(mockCurrentPeriod);
 
       // Test with node environment
       (getClient as Mock).mockReturnValue(null);

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getPermissionStatus.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getPermissionStatus.test.ts
@@ -1,7 +1,7 @@
 import { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
 import {
-    spendPermissionManagerAbi,
-    spendPermissionManagerAddress,
+  spendPermissionManagerAbi,
+  spendPermissionManagerAddress,
 } from ':sign/base-account/utils/constants.js';
 import { getClient } from ':store/chain-clients/utils.js';
 import { PublicClient, createPublicClient, http } from 'viem';

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getPermissionStatus.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getPermissionStatus.test.ts
@@ -1,7 +1,7 @@
 import { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
 import {
-  spendPermissionManagerAbi,
-  spendPermissionManagerAddress,
+    spendPermissionManagerAbi,
+    spendPermissionManagerAddress,
 } from ':sign/base-account/utils/constants.js';
 import { getClient } from ':store/chain-clients/utils.js';
 import { PublicClient, createPublicClient, http } from 'viem';
@@ -90,14 +90,16 @@ describe('getPermissionStatus - browser + node', () => {
         spend: BigInt('500000000000000000'), // 0.5 ETH spent
       };
       const mockIsRevoked = false;
-      const mockIsValid = true;
+
+      // Mock Date.now() to control the current timestamp
+      const originalDateNow = Date.now;
+      Date.now = vi.fn(() => 1234567890 * 1000); // Set to same as permission start time
 
       // Test with browser environment (client in store)
       (getClient as Mock).mockReturnValue(mockClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod) // getCurrentPeriod
-        .mockResolvedValueOnce(mockIsRevoked) // isRevoked
-        .mockResolvedValueOnce(mockIsValid); // isValid
+        .mockResolvedValueOnce(mockIsRevoked); // isRevoked
 
       const result: GetPermissionStatusResponseType =
         await getPermissionStatus(mockSpendPermission);
@@ -105,26 +107,30 @@ describe('getPermissionStatus - browser + node', () => {
       expect(result).toEqual({
         remainingSpend: BigInt('500000000000000000'), // 1 ETH - 0.5 ETH = 0.5 ETH remaining
         nextPeriodStart: new Date(1641081601 * 1000), // end + 1 converted to Date
-        isActive: true, // not revoked and valid
+        isRevoked: false,
+        isExpired: false, // current time (1234567890) < end time (1234654290)
+        isActive: true, // not revoked and not expired
       });
 
       expect(getClient).toHaveBeenCalledWith(8453);
       expect(toSpendPermissionArgs).toHaveBeenCalledWith(mockSpendPermission);
-      expect(readContract).toHaveBeenCalledTimes(3);
+      expect(readContract).toHaveBeenCalledTimes(2);
 
       // Test with node environment (no client in store)
       (getClient as Mock).mockReturnValue(null);
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod) // getCurrentPeriod
-        .mockResolvedValueOnce(mockIsRevoked) // isRevoked
-        .mockResolvedValueOnce(mockIsValid); // isValid
+        .mockResolvedValueOnce(mockIsRevoked); // isRevoked
 
       const nodeResult: GetPermissionStatusResponseType =
         await getPermissionStatus(mockSpendPermission);
 
       expect(nodeResult).toEqual(result);
       expect(getPublicClientFromChainIdSpy).toHaveBeenCalledWith(8453);
+
+      // Restore Date.now
+      Date.now = originalDateNow;
     });
 
     it('should return zero remaining spend when allowance is exceeded', async () => {
@@ -134,18 +140,22 @@ describe('getPermissionStatus - browser + node', () => {
         spend: BigInt('1500000000000000000'), // 1.5 ETH spent (more than allowance)
       };
       const mockIsRevoked = false;
-      const mockIsValid = true;
+
+      // Mock Date.now() to control the current timestamp
+      const originalDateNow = Date.now;
+      Date.now = vi.fn(() => 1234567890 * 1000); // Set to same as permission start time
 
       // Test with browser environment
       (getClient as Mock).mockReturnValue(mockClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(mockIsRevoked)
-        .mockResolvedValueOnce(mockIsValid);
+        .mockResolvedValueOnce(mockIsRevoked);
 
       const result = await getPermissionStatus(mockSpendPermission);
 
       expect(result.remainingSpend).toBe(BigInt(0));
+      expect(result.isRevoked).toBe(false);
+      expect(result.isExpired).toBe(false);
       expect(result.isActive).toBe(true);
 
       // Test with node environment
@@ -153,12 +163,14 @@ describe('getPermissionStatus - browser + node', () => {
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(mockIsRevoked)
-        .mockResolvedValueOnce(mockIsValid);
+        .mockResolvedValueOnce(mockIsRevoked);
 
       const nodeResult = await getPermissionStatus(mockSpendPermission);
 
       expect(nodeResult).toEqual(result);
+
+      // Restore Date.now
+      Date.now = originalDateNow;
     });
 
     it('should return inactive status when permission is revoked', async () => {
@@ -168,17 +180,21 @@ describe('getPermissionStatus - browser + node', () => {
         spend: BigInt('0'),
       };
       const mockIsRevoked = true;
-      const mockIsValid = true;
+
+      // Mock Date.now() to control the current timestamp
+      const originalDateNow = Date.now;
+      Date.now = vi.fn(() => 1234567890 * 1000); // Set to same as permission start time
 
       // Test with browser environment
       (getClient as Mock).mockReturnValue(mockClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(mockIsRevoked)
-        .mockResolvedValueOnce(mockIsValid);
+        .mockResolvedValueOnce(mockIsRevoked);
 
       const result = await getPermissionStatus(mockSpendPermission);
 
+      expect(result.isRevoked).toBe(true);
+      expect(result.isExpired).toBe(false);
       expect(result.isActive).toBe(false);
 
       // Test with node environment
@@ -186,32 +202,38 @@ describe('getPermissionStatus - browser + node', () => {
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(mockIsRevoked)
-        .mockResolvedValueOnce(mockIsValid);
+        .mockResolvedValueOnce(mockIsRevoked);
 
       const nodeResult = await getPermissionStatus(mockSpendPermission);
 
       expect(nodeResult).toEqual(result);
+
+      // Restore Date.now
+      Date.now = originalDateNow;
     });
 
-    it('should return inactive status when permission is invalid', async () => {
+    it('should return inactive status when permission is expired', async () => {
       const mockCurrentPeriod = {
         start: 1640995200,
         end: 1641081600,
         spend: BigInt('0'),
       };
       const mockIsRevoked = false;
-      const mockIsValid = false;
+
+      // Mock Date.now() to be after the permission end time
+      const originalDateNow = Date.now;
+      Date.now = vi.fn(() => 1234654291 * 1000); // Set to after permission end time (1234654290)
 
       // Test with browser environment
       (getClient as Mock).mockReturnValue(mockClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(mockIsRevoked)
-        .mockResolvedValueOnce(mockIsValid);
+        .mockResolvedValueOnce(mockIsRevoked);
 
       const result = await getPermissionStatus(mockSpendPermission);
 
+      expect(result.isRevoked).toBe(false);
+      expect(result.isExpired).toBe(true);
       expect(result.isActive).toBe(false);
 
       // Test with node environment
@@ -219,16 +241,22 @@ describe('getPermissionStatus - browser + node', () => {
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(mockIsRevoked)
-        .mockResolvedValueOnce(mockIsValid);
+        .mockResolvedValueOnce(mockIsRevoked);
 
       const nodeResult = await getPermissionStatus(mockSpendPermission);
 
       expect(nodeResult).toEqual(result);
+
+      // Restore Date.now
+      Date.now = originalDateNow;
     });
 
     it('should handle different chain IDs correctly', async () => {
       const testChainIds = [1, 8453, 137, 42161];
+
+      // Mock Date.now() to control the current timestamp
+      const originalDateNow = Date.now;
+      Date.now = vi.fn(() => 1234567890 * 1000); // Set to same as permission start time
 
       for (const chainId of testChainIds) {
         const permission = { ...mockSpendPermission, chainId };
@@ -238,8 +266,7 @@ describe('getPermissionStatus - browser + node', () => {
         (getClient as Mock).mockReturnValue(mockClient);
         (readContract as Mock)
           .mockResolvedValueOnce(mockCurrentPeriod)
-          .mockResolvedValueOnce(false)
-          .mockResolvedValueOnce(true);
+          .mockResolvedValueOnce(false);
 
         await getPermissionStatus(permission);
 
@@ -250,13 +277,15 @@ describe('getPermissionStatus - browser + node', () => {
         getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
         (readContract as Mock)
           .mockResolvedValueOnce(mockCurrentPeriod)
-          .mockResolvedValueOnce(false)
-          .mockResolvedValueOnce(true);
+          .mockResolvedValueOnce(false);
 
         await getPermissionStatus(permission);
 
         expect(getPublicClientFromChainIdSpy).toHaveBeenCalledWith(chainId);
       }
+
+      // Restore Date.now
+      Date.now = originalDateNow;
     });
   });
 
@@ -358,6 +387,10 @@ describe('getPermissionStatus - browser + node', () => {
       async (environment, getPermissionStatusFunc) => {
         const mockCurrentPeriod = { start: 1, end: 2, spend: BigInt('0') };
 
+        // Mock Date.now() to control the current timestamp
+        const originalDateNow = Date.now;
+        Date.now = vi.fn(() => 1234567890 * 1000); // Set to same as permission start time
+
         if (environment === 'browser') {
           (getClient as Mock).mockReturnValue(mockClient);
         } else {
@@ -367,12 +400,11 @@ describe('getPermissionStatus - browser + node', () => {
 
         (readContract as Mock)
           .mockResolvedValueOnce(mockCurrentPeriod)
-          .mockResolvedValueOnce(false)
-          .mockResolvedValueOnce(true);
+          .mockResolvedValueOnce(false);
 
         await getPermissionStatusFunc(mockSpendPermission);
 
-        expect(readContract).toHaveBeenCalledTimes(3);
+        expect(readContract).toHaveBeenCalledTimes(2);
 
         // Verify getCurrentPeriod call
         expect(readContract).toHaveBeenNthCalledWith(1, mockClient, {
@@ -390,13 +422,8 @@ describe('getPermissionStatus - browser + node', () => {
           args: [mockSpendPermissionArgs],
         });
 
-        // Verify isValid call
-        expect(readContract).toHaveBeenNthCalledWith(3, mockClient, {
-          address: spendPermissionManagerAddress,
-          abi: spendPermissionManagerAbi,
-          functionName: 'isValid',
-          args: [mockSpendPermissionArgs],
-        });
+        // Restore Date.now
+        Date.now = originalDateNow;
       }
     );
 
@@ -408,6 +435,10 @@ describe('getPermissionStatus - browser + node', () => {
       async (environment, getPermissionStatusFunc) => {
         const mockCurrentPeriod = { start: 1, end: 2, spend: BigInt('0') };
 
+        // Mock Date.now() to control the current timestamp
+        const originalDateNow = Date.now;
+        Date.now = vi.fn(() => 1234567890 * 1000); // Set to same as permission start time
+
         if (environment === 'browser') {
           (getClient as Mock).mockReturnValue(mockClient);
         } else {
@@ -418,7 +449,6 @@ describe('getPermissionStatus - browser + node', () => {
         // Create promises that we can control
         let resolveGetCurrentPeriod: (value: any) => void;
         let resolveIsRevoked: (value: any) => void;
-        let resolveIsValid: (value: any) => void;
 
         const getCurrentPeriodPromise = new Promise((resolve) => {
           resolveGetCurrentPeriod = resolve;
@@ -426,26 +456,24 @@ describe('getPermissionStatus - browser + node', () => {
         const isRevokedPromise = new Promise((resolve) => {
           resolveIsRevoked = resolve;
         });
-        const isValidPromise = new Promise((resolve) => {
-          resolveIsValid = resolve;
-        });
 
         (readContract as Mock)
           .mockReturnValueOnce(getCurrentPeriodPromise)
-          .mockReturnValueOnce(isRevokedPromise)
-          .mockReturnValueOnce(isValidPromise);
+          .mockReturnValueOnce(isRevokedPromise);
 
         const statusPromise = getPermissionStatusFunc(mockSpendPermission);
 
         // Verify all contract calls are made immediately
-        expect(readContract).toHaveBeenCalledTimes(3);
+        expect(readContract).toHaveBeenCalledTimes(2);
 
         // Resolve all promises
         resolveGetCurrentPeriod!(mockCurrentPeriod);
         resolveIsRevoked!(false);
-        resolveIsValid!(true);
 
         await statusPromise;
+
+        // Restore Date.now
+        Date.now = originalDateNow;
       }
     );
   });
@@ -462,12 +490,15 @@ describe('getPermissionStatus - browser + node', () => {
 
       const mockCurrentPeriod = { start: 1, end: 2, spend: BigInt('0') };
 
+      // Mock Date.now() to control the current timestamp
+      const originalDateNow = Date.now;
+      Date.now = vi.fn(() => 1234567890 * 1000); // Set to same as permission start time
+
       // Test with browser environment
       (getClient as Mock).mockReturnValue(mockClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(false);
 
       const result = await getPermissionStatus(permissionWithZeroAllowance);
 
@@ -478,12 +509,14 @@ describe('getPermissionStatus - browser + node', () => {
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(false);
 
       const nodeResult = await getPermissionStatus(permissionWithZeroAllowance);
 
       expect(nodeResult).toEqual(result);
+
+      // Restore Date.now
+      Date.now = originalDateNow;
     });
 
     it('should handle very large allowance values', async () => {
@@ -501,12 +534,15 @@ describe('getPermissionStatus - browser + node', () => {
         spend: BigInt('1000000000000000000'),
       };
 
+      // Mock Date.now() to control the current timestamp
+      const originalDateNow = Date.now;
+      Date.now = vi.fn(() => 1234567890 * 1000); // Set to same as permission start time
+
       // Test with browser environment
       (getClient as Mock).mockReturnValue(mockClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(false);
 
       const result = await getPermissionStatus(permissionWithLargeAllowance);
 
@@ -519,12 +555,14 @@ describe('getPermissionStatus - browser + node', () => {
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(false);
 
       const nodeResult = await getPermissionStatus(permissionWithLargeAllowance);
 
       expect(nodeResult).toEqual(result);
+
+      // Restore Date.now
+      Date.now = originalDateNow;
     });
 
     it('should handle period end at maximum timestamp', async () => {
@@ -534,12 +572,15 @@ describe('getPermissionStatus - browser + node', () => {
         spend: BigInt('0'),
       };
 
+      // Mock Date.now() to control the current timestamp
+      const originalDateNow = Date.now;
+      Date.now = vi.fn(() => 1234567890 * 1000); // Set to same as permission start time
+
       // Test with browser environment
       (getClient as Mock).mockReturnValue(mockClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(false);
 
       const result = await getPermissionStatus(mockSpendPermission);
 
@@ -550,12 +591,14 @@ describe('getPermissionStatus - browser + node', () => {
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(false);
 
       const nodeResult = await getPermissionStatus(mockSpendPermission);
 
       expect(nodeResult).toEqual(result);
+
+      // Restore Date.now
+      Date.now = originalDateNow;
     });
   });
 });

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getPermissionStatus.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getPermissionStatus.test.ts
@@ -1,7 +1,7 @@
 import { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
 import {
-    spendPermissionManagerAbi,
-    spendPermissionManagerAddress,
+  spendPermissionManagerAbi,
+  spendPermissionManagerAddress,
 } from ':sign/base-account/utils/constants.js';
 import { getClient } from ':store/chain-clients/utils.js';
 import { PublicClient, createPublicClient, http } from 'viem';
@@ -496,9 +496,7 @@ describe('getPermissionStatus - browser + node', () => {
 
       // Test with browser environment
       (getClient as Mock).mockReturnValue(mockClient);
-      (readContract as Mock)
-        .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(false);
+      (readContract as Mock).mockResolvedValueOnce(mockCurrentPeriod).mockResolvedValueOnce(false);
 
       const result = await getPermissionStatus(permissionWithZeroAllowance);
 
@@ -507,9 +505,7 @@ describe('getPermissionStatus - browser + node', () => {
       // Test with node environment
       (getClient as Mock).mockReturnValue(null);
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
-      (readContract as Mock)
-        .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(false);
+      (readContract as Mock).mockResolvedValueOnce(mockCurrentPeriod).mockResolvedValueOnce(false);
 
       const nodeResult = await getPermissionStatus(permissionWithZeroAllowance);
 
@@ -540,9 +536,7 @@ describe('getPermissionStatus - browser + node', () => {
 
       // Test with browser environment
       (getClient as Mock).mockReturnValue(mockClient);
-      (readContract as Mock)
-        .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(false);
+      (readContract as Mock).mockResolvedValueOnce(mockCurrentPeriod).mockResolvedValueOnce(false);
 
       const result = await getPermissionStatus(permissionWithLargeAllowance);
 
@@ -553,9 +547,7 @@ describe('getPermissionStatus - browser + node', () => {
       // Test with node environment
       (getClient as Mock).mockReturnValue(null);
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
-      (readContract as Mock)
-        .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(false);
+      (readContract as Mock).mockResolvedValueOnce(mockCurrentPeriod).mockResolvedValueOnce(false);
 
       const nodeResult = await getPermissionStatus(permissionWithLargeAllowance);
 
@@ -578,9 +570,7 @@ describe('getPermissionStatus - browser + node', () => {
 
       // Test with browser environment
       (getClient as Mock).mockReturnValue(mockClient);
-      (readContract as Mock)
-        .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(false);
+      (readContract as Mock).mockResolvedValueOnce(mockCurrentPeriod).mockResolvedValueOnce(false);
 
       const result = await getPermissionStatus(mockSpendPermission);
 
@@ -589,9 +579,7 @@ describe('getPermissionStatus - browser + node', () => {
       // Test with node environment
       (getClient as Mock).mockReturnValue(null);
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
-      (readContract as Mock)
-        .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(false);
+      (readContract as Mock).mockResolvedValueOnce(mockCurrentPeriod).mockResolvedValueOnce(false);
 
       const nodeResult = await getPermissionStatus(mockSpendPermission);
 

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getPermissionStatus.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getPermissionStatus.ts
@@ -16,6 +16,11 @@ export type GetPermissionStatusResponseType = {
   isRevoked: boolean;
   isExpired: boolean;
   isActive: boolean;
+  currentPeriod: {
+    start: number;
+    end: number;
+    spend: bigint;
+  };
 };
 
 /**
@@ -112,6 +117,7 @@ const getPermissionStatusFn = async (
     isRevoked,
     isExpired,
     isActive,
+    currentPeriod,
   };
 };
 

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareSpendCallData.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareSpendCallData.test.ts
@@ -59,6 +59,8 @@ describe('prepareSpendCallData', () => {
     remainingSpend: BigInt('500000000000000000'), // 0.5 ETH remaining
     nextPeriodStart: new Date('2024-01-01T00:00:00Z'),
     isActive: true,
+    isRevoked: false,
+    isExpired: false,
   };
 
   beforeEach(() => {
@@ -276,6 +278,8 @@ describe('prepareSpendCallData', () => {
       remainingSpend: BigInt('500000000000000000'),
       nextPeriodStart: new Date('2024-01-01T00:00:00Z'),
       isActive: false,
+      isRevoked: true,
+      isExpired: false,
     });
 
     const result = await prepareSpendCallData(mockSpendPermission, 'max-remaining-allowance');
@@ -289,6 +293,8 @@ describe('prepareSpendCallData', () => {
       remainingSpend: BigInt('500000000000000000'),
       nextPeriodStart: new Date('2024-01-01T00:00:00Z'),
       isActive: true,
+      isRevoked: false,
+      isExpired: false,
     };
     mockGetPermissionStatus.mockResolvedValue(status);
 
@@ -393,6 +399,8 @@ describe('prepareSpendCallData', () => {
       remainingSpend: BigInt('500000000000000000'),
       nextPeriodStart: new Date('2024-01-01T00:00:00Z'),
       isActive: false,
+      isRevoked: false,
+      isExpired: true,
     };
     mockGetPermissionStatus.mockResolvedValue(status);
 
@@ -413,6 +421,8 @@ describe('prepareSpendCallData', () => {
       remainingSpend: BigInt('0'),
       nextPeriodStart: new Date('2024-01-01T00:00:00Z'),
       isActive: true,
+      isRevoked: false,
+      isExpired: false,
     };
     mockGetPermissionStatus.mockResolvedValue(status);
 
@@ -426,6 +436,8 @@ describe('prepareSpendCallData', () => {
       remainingSpend: BigInt('500000000000000000'),
       nextPeriodStart: new Date('2024-01-01T00:00:00Z'),
       isActive: false,
+      isRevoked: false,
+      isExpired: true,
     };
     mockGetPermissionStatus.mockResolvedValue(status);
 


### PR DESCRIPTION
## What changed? Why?

Updated the permission status API to properly ignore the on-chain distinction (it shouldn't matter to our consumers), provide more granular information about permission states and reduce unnecessary blockchain calls.

### Changes to getPermissionStatus:
- Added `isRevoked` and `isExpired` fields to the return type
- Removed the `isValid` blockchain call (We don't care if the permission is on-chain yet)
- Calculate `isExpired` locally by comparing current timestamp with permission end time
- `isActive` now computed as `!isRevoked && !isExpired`

### Changes to getSubscriptionStatus:
- Simplified logic to use `isActive` directly from `getPermissionStatus`
- Removed redundant expired logic and `hasNoOnChainState` checks
- `isSubscribed` now directly equals `status.isActive`

## How was this tested?

manually + unit

## How can reviewers manually test these changes?

1. Check out the branch: `git checkout spencer/update-permission-status-api`
2. Install dependencies: `yarn install`
3. Run tests: `yarn test --run`
4. Run type checking: `yarn typecheck`
5. Run linting: `yarn lint`

The `getPermissionStatus` function now returns:
- `remainingSpend`: Amount that can still be spent in current period
- `nextPeriodStart`: When the next period begins
- `isRevoked`: Whether the permission has been revoked on-chain
- `isExpired`: Whether the permission has expired based on current time
- `isActive`: Computed as `!isRevoked && !isExpired`
- `currentPeriod`: the entire current period

## Demo/screenshots


