### PR TITLE
Bump @base-org/account version to 2.3.0

### DIFF
--- a/packages/account-sdk/package.json
+++ b/packages/account-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@base-org/account",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Base Account SDK",
   "keywords": [
     "base",


### PR DESCRIPTION
## What changed? Why?

Bumped @base-org/account package version from 2.2.0 to 2.3.0.

## How was this tested?

Version bump only - no functional changes to test.

## How can reviewers manually test these changes?

N/A - version bump only.

## Demo/screenshots

N/A


