### PR TITLE
Fix permission status check in prepareSpendCallData

### DIFF
--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getPermissionStatus.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/getPermissionStatus.test.ts
@@ -99,7 +99,8 @@ describe('getPermissionStatus - browser + node', () => {
       (getClient as Mock).mockReturnValue(mockClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod) // getCurrentPeriod
-        .mockResolvedValueOnce(mockIsRevoked); // isRevoked
+        .mockResolvedValueOnce(mockIsRevoked) // isRevoked
+        .mockResolvedValueOnce(true); // isValid (approved onchain)
 
       const result: GetPermissionStatusResponseType =
         await getPermissionStatus(mockSpendPermission);
@@ -110,19 +111,21 @@ describe('getPermissionStatus - browser + node', () => {
         isRevoked: false,
         isExpired: false, // current time (1234567890) < end time (1234654290)
         isActive: true, // not revoked and not expired
+        isApprovedOnchain: true, // isValid returns true
         currentPeriod: mockCurrentPeriod,
       });
 
       expect(getClient).toHaveBeenCalledWith(8453);
       expect(toSpendPermissionArgs).toHaveBeenCalledWith(mockSpendPermission);
-      expect(readContract).toHaveBeenCalledTimes(2);
+      expect(readContract).toHaveBeenCalledTimes(3);
 
       // Test with node environment (no client in store)
       (getClient as Mock).mockReturnValue(null);
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod) // getCurrentPeriod
-        .mockResolvedValueOnce(mockIsRevoked); // isRevoked
+        .mockResolvedValueOnce(mockIsRevoked) // isRevoked
+        .mockResolvedValueOnce(true); // isValid (approved onchain)
 
       const nodeResult: GetPermissionStatusResponseType =
         await getPermissionStatus(mockSpendPermission);
@@ -150,7 +153,8 @@ describe('getPermissionStatus - browser + node', () => {
       (getClient as Mock).mockReturnValue(mockClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(mockIsRevoked);
+        .mockResolvedValueOnce(mockIsRevoked)
+        .mockResolvedValueOnce(true); // isValid
 
       const result = await getPermissionStatus(mockSpendPermission);
 
@@ -158,6 +162,7 @@ describe('getPermissionStatus - browser + node', () => {
       expect(result.isRevoked).toBe(false);
       expect(result.isExpired).toBe(false);
       expect(result.isActive).toBe(true);
+      expect(result.isApprovedOnchain).toBe(true);
       expect(result.currentPeriod).toEqual(mockCurrentPeriod);
 
       // Test with node environment
@@ -165,7 +170,8 @@ describe('getPermissionStatus - browser + node', () => {
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(mockIsRevoked);
+        .mockResolvedValueOnce(mockIsRevoked)
+        .mockResolvedValueOnce(true); // isValid
 
       const nodeResult = await getPermissionStatus(mockSpendPermission);
 
@@ -191,13 +197,15 @@ describe('getPermissionStatus - browser + node', () => {
       (getClient as Mock).mockReturnValue(mockClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(mockIsRevoked);
+        .mockResolvedValueOnce(mockIsRevoked)
+        .mockResolvedValueOnce(true); // isValid
 
       const result = await getPermissionStatus(mockSpendPermission);
 
       expect(result.isRevoked).toBe(true);
       expect(result.isExpired).toBe(false);
       expect(result.isActive).toBe(false);
+      expect(result.isApprovedOnchain).toBe(true);
       expect(result.currentPeriod).toEqual(mockCurrentPeriod);
 
       // Test with node environment
@@ -205,7 +213,8 @@ describe('getPermissionStatus - browser + node', () => {
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(mockIsRevoked);
+        .mockResolvedValueOnce(mockIsRevoked)
+        .mockResolvedValueOnce(true); // isValid
 
       const nodeResult = await getPermissionStatus(mockSpendPermission);
 
@@ -231,13 +240,15 @@ describe('getPermissionStatus - browser + node', () => {
       (getClient as Mock).mockReturnValue(mockClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(mockIsRevoked);
+        .mockResolvedValueOnce(mockIsRevoked)
+        .mockResolvedValueOnce(true); // isValid
 
       const result = await getPermissionStatus(mockSpendPermission);
 
       expect(result.isRevoked).toBe(false);
       expect(result.isExpired).toBe(true);
       expect(result.isActive).toBe(false);
+      expect(result.isApprovedOnchain).toBe(true);
       expect(result.currentPeriod).toEqual(mockCurrentPeriod);
 
       // Test with node environment
@@ -245,7 +256,8 @@ describe('getPermissionStatus - browser + node', () => {
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
       (readContract as Mock)
         .mockResolvedValueOnce(mockCurrentPeriod)
-        .mockResolvedValueOnce(mockIsRevoked);
+        .mockResolvedValueOnce(mockIsRevoked)
+        .mockResolvedValueOnce(true); // isValid
 
       const nodeResult = await getPermissionStatus(mockSpendPermission);
 
@@ -404,11 +416,12 @@ describe('getPermissionStatus - browser + node', () => {
 
         (readContract as Mock)
           .mockResolvedValueOnce(mockCurrentPeriod)
-          .mockResolvedValueOnce(false);
+          .mockResolvedValueOnce(false)
+          .mockResolvedValueOnce(true); // isValid
 
         await getPermissionStatusFunc(mockSpendPermission);
 
-        expect(readContract).toHaveBeenCalledTimes(2);
+        expect(readContract).toHaveBeenCalledTimes(3);
 
         // Verify getCurrentPeriod call
         expect(readContract).toHaveBeenNthCalledWith(1, mockClient, {
@@ -423,6 +436,14 @@ describe('getPermissionStatus - browser + node', () => {
           address: spendPermissionManagerAddress,
           abi: spendPermissionManagerAbi,
           functionName: 'isRevoked',
+          args: [mockSpendPermissionArgs],
+        });
+
+        // Verify isValid call
+        expect(readContract).toHaveBeenNthCalledWith(3, mockClient, {
+          address: spendPermissionManagerAddress,
+          abi: spendPermissionManagerAbi,
+          functionName: 'isValid',
           args: [mockSpendPermissionArgs],
         });
 
@@ -453,6 +474,7 @@ describe('getPermissionStatus - browser + node', () => {
         // Create promises that we can control
         let resolveGetCurrentPeriod: (value: any) => void;
         let resolveIsRevoked: (value: any) => void;
+        let resolveIsValid: (value: any) => void;
 
         const getCurrentPeriodPromise = new Promise((resolve) => {
           resolveGetCurrentPeriod = resolve;
@@ -460,19 +482,24 @@ describe('getPermissionStatus - browser + node', () => {
         const isRevokedPromise = new Promise((resolve) => {
           resolveIsRevoked = resolve;
         });
+        const isValidPromise = new Promise((resolve) => {
+          resolveIsValid = resolve;
+        });
 
         (readContract as Mock)
           .mockReturnValueOnce(getCurrentPeriodPromise)
-          .mockReturnValueOnce(isRevokedPromise);
+          .mockReturnValueOnce(isRevokedPromise)
+          .mockReturnValueOnce(isValidPromise);
 
         const statusPromise = getPermissionStatusFunc(mockSpendPermission);
 
         // Verify all contract calls are made immediately
-        expect(readContract).toHaveBeenCalledTimes(2);
+        expect(readContract).toHaveBeenCalledTimes(3);
 
         // Resolve all promises
         resolveGetCurrentPeriod!(mockCurrentPeriod);
         resolveIsRevoked!(false);
+        resolveIsValid!(true);
 
         await statusPromise;
 
@@ -500,7 +527,10 @@ describe('getPermissionStatus - browser + node', () => {
 
       // Test with browser environment
       (getClient as Mock).mockReturnValue(mockClient);
-      (readContract as Mock).mockResolvedValueOnce(mockCurrentPeriod).mockResolvedValueOnce(false);
+      (readContract as Mock)
+        .mockResolvedValueOnce(mockCurrentPeriod)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true); // isValid
 
       const result = await getPermissionStatus(permissionWithZeroAllowance);
 
@@ -510,7 +540,10 @@ describe('getPermissionStatus - browser + node', () => {
       // Test with node environment
       (getClient as Mock).mockReturnValue(null);
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
-      (readContract as Mock).mockResolvedValueOnce(mockCurrentPeriod).mockResolvedValueOnce(false);
+      (readContract as Mock)
+        .mockResolvedValueOnce(mockCurrentPeriod)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true); // isValid
 
       const nodeResult = await getPermissionStatus(permissionWithZeroAllowance);
 
@@ -541,7 +574,10 @@ describe('getPermissionStatus - browser + node', () => {
 
       // Test with browser environment
       (getClient as Mock).mockReturnValue(mockClient);
-      (readContract as Mock).mockResolvedValueOnce(mockCurrentPeriod).mockResolvedValueOnce(false);
+      (readContract as Mock)
+        .mockResolvedValueOnce(mockCurrentPeriod)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true); // isValid
 
       const result = await getPermissionStatus(permissionWithLargeAllowance);
 
@@ -553,7 +589,10 @@ describe('getPermissionStatus - browser + node', () => {
       // Test with node environment
       (getClient as Mock).mockReturnValue(null);
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
-      (readContract as Mock).mockResolvedValueOnce(mockCurrentPeriod).mockResolvedValueOnce(false);
+      (readContract as Mock)
+        .mockResolvedValueOnce(mockCurrentPeriod)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true); // isValid
 
       const nodeResult = await getPermissionStatus(permissionWithLargeAllowance);
 
@@ -576,7 +615,10 @@ describe('getPermissionStatus - browser + node', () => {
 
       // Test with browser environment
       (getClient as Mock).mockReturnValue(mockClient);
-      (readContract as Mock).mockResolvedValueOnce(mockCurrentPeriod).mockResolvedValueOnce(false);
+      (readContract as Mock)
+        .mockResolvedValueOnce(mockCurrentPeriod)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true); // isValid
 
       const result = await getPermissionStatus(mockSpendPermission);
 
@@ -586,7 +628,10 @@ describe('getPermissionStatus - browser + node', () => {
       // Test with node environment
       (getClient as Mock).mockReturnValue(null);
       getPublicClientFromChainIdSpy.mockReturnValue(mockClient as unknown as PublicClient);
-      (readContract as Mock).mockResolvedValueOnce(mockCurrentPeriod).mockResolvedValueOnce(false);
+      (readContract as Mock)
+        .mockResolvedValueOnce(mockCurrentPeriod)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true); // isValid
 
       const nodeResult = await getPermissionStatus(mockSpendPermission);
 

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareSpendCallData.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareSpendCallData.test.ts
@@ -35,6 +35,7 @@ function createMockPermissionStatus(
     isActive: true,
     isRevoked: false,
     isExpired: false,
+    isApprovedOnchain: true,
     currentPeriod: {
       start: 1234567890,
       end: 1234654290,
@@ -98,8 +99,10 @@ describe('prepareSpendCallData', () => {
     });
   });
 
-  it('should prepare call data for approve and spend operations when permission is not active', async () => {
-    mockGetPermissionStatus.mockResolvedValue(createMockPermissionStatus({ isActive: false }));
+  it('should prepare call data for approve and spend operations when permission is not approved onchain', async () => {
+    mockGetPermissionStatus.mockResolvedValue(
+      createMockPermissionStatus({ isApprovedOnchain: false })
+    );
 
     const result = await prepareSpendCallData(mockSpendPermission, 'max-remaining-allowance');
 
@@ -128,7 +131,7 @@ describe('prepareSpendCallData', () => {
       value: 0n,
     });
 
-    // Verify approve call is not made when permission is active
+    // Verify approve call is not made when permission is already approved onchain
     expect(mockEncodeFunctionData).not.toHaveBeenCalledWith({
       abi: spendPermissionManagerAbi,
       functionName: 'approveWithSignature',
@@ -173,8 +176,10 @@ describe('prepareSpendCallData', () => {
     expect(mockToSpendPermissionArgs).toHaveBeenCalledWith(mockSpendPermission);
   });
 
-  it('should encode approveWithSignature function data correctly when permission is not active', async () => {
-    mockGetPermissionStatus.mockResolvedValue(createMockPermissionStatus({ isActive: false }));
+  it('should encode approveWithSignature function data correctly when permission is not approved onchain', async () => {
+    mockGetPermissionStatus.mockResolvedValue(
+      createMockPermissionStatus({ isApprovedOnchain: false })
+    );
 
     await prepareSpendCallData(mockSpendPermission, 'max-remaining-allowance');
 
@@ -197,8 +202,10 @@ describe('prepareSpendCallData', () => {
     });
   });
 
-  it('should return calls with correct structure when permission is not active', async () => {
-    mockGetPermissionStatus.mockResolvedValue(createMockPermissionStatus({ isActive: false }));
+  it('should return calls with correct structure when permission is not approved onchain', async () => {
+    mockGetPermissionStatus.mockResolvedValue(
+      createMockPermissionStatus({ isApprovedOnchain: false })
+    );
 
     const result = await prepareSpendCallData(mockSpendPermission, 'max-remaining-allowance');
 
@@ -219,7 +226,7 @@ describe('prepareSpendCallData', () => {
     expect(typedResult[1].value).toBe(0n);
   });
 
-  it('should return calls with correct structure when permission is active', async () => {
+  it('should return calls with correct structure when permission is already approved onchain', async () => {
     mockGetPermissionStatus.mockResolvedValue(createMockPermissionStatus());
 
     const result = await prepareSpendCallData(mockSpendPermission, 'max-remaining-allowance');
@@ -271,10 +278,10 @@ describe('prepareSpendCallData', () => {
     });
   });
 
-  it('should use the same spendPermissionManagerAddress for both calls when permission is not active', async () => {
+  it('should use the same spendPermissionManagerAddress for both calls when permission is not approved onchain', async () => {
     mockGetPermissionStatus.mockResolvedValue(
       createMockPermissionStatus({
-        isActive: false,
+        isApprovedOnchain: false,
         isRevoked: true,
       })
     );
@@ -285,7 +292,7 @@ describe('prepareSpendCallData', () => {
     expect(result[1].to).toBe(spendPermissionManagerAddress);
   });
 
-  it('should use the same spendPermissionManagerAddress for spend call when permission is active', async () => {
+  it('should use the same spendPermissionManagerAddress for spend call when permission is already approved onchain', async () => {
     mockGetPermissionStatus.mockResolvedValue(createMockPermissionStatus());
 
     const result = await prepareSpendCallData(mockSpendPermission, 'max-remaining-allowance');
@@ -385,10 +392,10 @@ describe('prepareSpendCallData', () => {
     expect(result[0].to).toBe(spendPermissionManagerAddress);
   });
 
-  it('should set value to 0x0 for both calls when permission is not active', async () => {
+  it('should set value to 0x0 for both calls when permission is not approved onchain', async () => {
     mockGetPermissionStatus.mockResolvedValue(
       createMockPermissionStatus({
-        isActive: false,
+        isApprovedOnchain: false,
         isExpired: true,
       })
     );
@@ -399,7 +406,7 @@ describe('prepareSpendCallData', () => {
     expect(result[1].value).toBe(0n);
   });
 
-  it('should set value to 0x0 for spend call when permission is active', async () => {
+  it('should set value to 0x0 for spend call when permission is already approved onchain', async () => {
     const result = await prepareSpendCallData(mockSpendPermission, 'max-remaining-allowance');
 
     expect(result[0].value).toBe(0n);
@@ -418,14 +425,14 @@ describe('prepareSpendCallData', () => {
   it('should work correctly when permission status indicates not approved', async () => {
     mockGetPermissionStatus.mockResolvedValue(
       createMockPermissionStatus({
-        isActive: false,
+        isApprovedOnchain: false,
         isExpired: true,
       })
     );
 
     const result = await prepareSpendCallData(mockSpendPermission, 'max-remaining-allowance');
 
-    // Should prepare both calls when permission is not active
+    // Should prepare both calls when permission is not approved onchain
     expect(result).toHaveLength(2);
     expect(mockEncodeFunctionData).toHaveBeenCalledWith({
       abi: spendPermissionManagerAbi,

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareSpendCallData.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareSpendCallData.test.ts
@@ -278,11 +278,23 @@ describe('prepareSpendCallData', () => {
     });
   });
 
+  it('should throw error when permission is revoked', async () => {
+    mockGetPermissionStatus.mockResolvedValue(
+      createMockPermissionStatus({
+        isRevoked: true,
+      })
+    );
+
+    await expect(
+      prepareSpendCallData(mockSpendPermission, 'max-remaining-allowance')
+    ).rejects.toThrow('Spend permission has been revoked');
+  });
+
   it('should use the same spendPermissionManagerAddress for both calls when permission is not approved onchain', async () => {
     mockGetPermissionStatus.mockResolvedValue(
       createMockPermissionStatus({
         isApprovedOnchain: false,
-        isRevoked: true,
+        isRevoked: false,
       })
     );
 

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareSpendCallData.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareSpendCallData.ts
@@ -40,6 +40,10 @@ export type PrepareSpendCallDataResponseType = Call[];
  *
  * @returns A promise that resolves to an array containing all the necessary calls.
  *
+ * @throws {Error} Throws an error if the spend permission has been revoked.
+ * @throws {Error} Throws an error if the spend amount is 0.
+ * @throws {Error} Throws an error if the spend amount exceeds the remaining allowance.
+ *
  * @example
  * ```typescript
  * import { prepareSpendCallData } from '@base-org/account/spend-permission';
@@ -109,7 +113,12 @@ const prepareSpendCallDataFn = async (
   amount: bigint | 'max-remaining-allowance',
   recipient?: Address
 ): Promise<PrepareSpendCallDataResponseType> => {
-  const { remainingSpend, isApprovedOnchain } = await getPermissionStatus(permission);
+  const { remainingSpend, isApprovedOnchain, isRevoked } = await getPermissionStatus(permission);
+
+  if (isRevoked) {
+    throw new Error('Spend permission has been revoked');
+  }
+
   const spendAmount = amount === 'max-remaining-allowance' ? remainingSpend : amount;
 
   if (spendAmount === BigInt(0)) {

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareSpendCallData.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareSpendCallData.ts
@@ -22,7 +22,7 @@ export type PrepareSpendCallDataResponseType = Call[];
  *
  * This helper method constructs the call data for `approveWithSignature`
  * and `spend` functions. The approve call is only included when the permission
- * is not yet active. If the permission is already approved, only the spend call is returned.
+ * is not yet approved onchain. If the permission is already approved, only the spend call is returned.
  *
  * When 'max-remaining-allowance' is provided as the amount, the function automatically uses all remaining
  * spend permission allowance.
@@ -109,7 +109,7 @@ const prepareSpendCallDataFn = async (
   amount: bigint | 'max-remaining-allowance',
   recipient?: Address
 ): Promise<PrepareSpendCallDataResponseType> => {
-  const { remainingSpend, isActive } = await getPermissionStatus(permission);
+  const { remainingSpend, isApprovedOnchain } = await getPermissionStatus(permission);
   const spendAmount = amount === 'max-remaining-allowance' ? remainingSpend : amount;
 
   if (spendAmount === BigInt(0)) {
@@ -124,7 +124,7 @@ const prepareSpendCallDataFn = async (
 
   const spendPermissionArgs = toSpendPermissionArgs(permission);
 
-  if (!isActive) {
+  if (!isApprovedOnchain) {
     const approveData = encodeFunctionData({
       abi: spendPermissionManagerAbi,
       functionName: 'approveWithSignature',


### PR DESCRIPTION
### _Summary_

Fixed permission status check in `prepareSpendCallData` to use `isApprovedOnchain` instead of `isActive` when determining if approval is needed.

The `isActive` field indicates whether a permission is currently usable (not revoked and not expired), but doesn't reflect whether it has been approved on-chain. The new `isApprovedOnchain` field (which calls the contract's `isValid` function) correctly determines if the permission needs to be approved before spending.

Key changes:
- Added `isApprovedOnchain` field to `GetPermissionStatusResponseType` that calls the contract's `isValid` function
- Updated `prepareSpendCallData` to check `isApprovedOnchain` instead of `isActive` when deciding whether to include the approve call
- Updated all related tests to verify the new `isApprovedOnchain` field

### _How did you test your changes?_

- Updated existing unit tests to verify the new `isApprovedOnchain` field is properly returned from `getPermissionStatus`
- Modified `prepareSpendCallData` tests to verify that approval calls are only included when `isApprovedOnchain` is false
- All tests pass with proper mocking of the `isValid` contract function
