### PR TITLE
wallet_sign in playground

### DIFF
--- a/examples/testapp/src/components/RpcMethods/method/ephemeralMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/ephemeralMethods.ts
@@ -1,3 +1,4 @@
+import { parseMessage } from '../shortcut/ShortcutType';
 import { RpcRequestInput } from './RpcRequestInput';
 
 const walletSendCallsEphemeral: RpcRequestInput = {
@@ -16,12 +17,48 @@ const walletSendCallsEphemeral: RpcRequestInput = {
   ],
 };
 
-const walletSignEphemeral: RpcRequestInput = {
-  method: 'wallet_sign',
-  params: [{ key: 'message', required: true }],
+const walletSignOldSpecEphemeral: RpcRequestInput = {
+  method: 'wallet_sign#old',
+  params: [
+    { key: 'version', required: true },
+    { key: 'type', required: true },
+    { key: 'address', required: false },
+    { key: 'data', required: true },
+    { key: 'capabilities', required: false },
+  ],
   format: (data: Record<string, string>) => [
-    `0x${Buffer.from(data.message, 'utf8').toString('hex')}`,
+    {
+      version: data.version,
+      type: data.type,
+      address: data.address,
+      data: parseMessage(data.data),
+      capabilities: data.capabilities,
+    },
   ],
 };
 
-export const ephemeralMethods = [walletSendCallsEphemeral, walletSignEphemeral];
+const walletSignNewSpecEphemeral: RpcRequestInput = {
+  method: 'wallet_sign#new',
+  params: [
+    { key: 'version', required: true },
+    { key: 'request', required: true },
+    { key: 'address', required: false },
+    { key: 'capabilities', required: false },
+    { key: 'mutableData', required: false },
+  ],
+  format: (data: Record<string, string>) => [
+    {
+      version: data.version,
+      request: parseMessage(data.request),
+      address: data.address,
+      mutableData: data.mutableData,
+      capabilities: data.capabilities,
+    },
+  ],
+};
+
+export const ephemeralMethods = [
+  walletSendCallsEphemeral,
+  walletSignOldSpecEphemeral,
+  walletSignNewSpecEphemeral,
+];

--- a/examples/testapp/src/components/RpcMethods/method/signMessageMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/signMessageMethods.ts
@@ -1,4 +1,4 @@
-import { Chain, createPublicClient, http, TypedDataDomain } from 'viem';
+import { Chain, TypedDataDomain, createPublicClient, http } from 'viem';
 
 import { parseMessage } from '../shortcut/ShortcutType';
 import { RpcRequestInput } from './RpcRequestInput';
@@ -54,12 +54,54 @@ const ethSignTypedDataV4: RpcRequestInput = {
   format: (data: Record<string, string>) => [data.address, parseMessage(data.message)],
 };
 
+const walletSignOldSpec: RpcRequestInput = {
+  method: 'wallet_sign#old',
+  params: [
+    { key: 'version', required: true },
+    { key: 'type', required: true },
+    { key: 'address', required: false },
+    { key: 'data', required: true },
+    { key: 'capabilities', required: false },
+  ],
+  format: (data: Record<string, string>) => [
+    {
+      version: data.version,
+      type: data.type,
+      address: data.address,
+      data: parseMessage(data.data),
+      capabilities: data.capabilities,
+    },
+  ],
+};
+
+const walletSignNewSpec: RpcRequestInput = {
+  method: 'wallet_sign#new',
+  params: [
+    { key: 'version', required: true },
+    { key: 'request', required: true },
+    { key: 'address', required: false },
+    { key: 'capabilities', required: false },
+    { key: 'mutableData', required: false },
+  ],
+  format: (data: Record<string, string>) => [
+    {
+      version: data.version,
+      request: parseMessage(data.request),
+      address: data.address,
+      mutableData: data.mutableData,
+      capabilities: data.capabilities,
+    },
+  ],
+};
+
 export const signMessageMethods = [
   ethSign,
   personalSign,
   ethSignTypedDataV1,
   ethSignTypedDataV3,
   ethSignTypedDataV4,
+  walletSignOldSpec,
+  walletSignNewSpec,
 ];
 
 export const verifySignMsg = async ({

--- a/examples/testapp/src/components/RpcMethods/shortcut/ephemeralMethodShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/ephemeralMethodShortcuts.ts
@@ -1,5 +1,53 @@
 import { ShortcutType } from './ShortcutType';
 
+const PLACEHOLDER_ADDRESS = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+const BASE_PAY_DATA = {
+  domain: {
+    chainId: 8453,
+    name: 'USDC',
+    verifyingContract: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+    version: '2',
+  },
+  message: {
+    from: PLACEHOLDER_ADDRESS,
+    nonce: '0xbda37619d3004dba4ac2491022bc82b7df64c2f68e8a349422c71983a80d16ca',
+    to: '0xbc4c0191af73c4953b54f21ae0c74b31fc6cb21b',
+    validAfter: '0',
+    validBefore: '1914749767655',
+    value: '10000',
+  },
+  primaryType: 'ReceiveWithAuthorization',
+  types: {
+    ReceiveWithAuthorization: [
+      {
+        name: 'from',
+        type: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+      },
+      {
+        name: 'value',
+        type: 'uint256',
+      },
+      {
+        name: 'validAfter',
+        type: 'uint256',
+      },
+      {
+        name: 'validBefore',
+        type: 'uint256',
+      },
+      {
+        name: 'nonce',
+        type: 'bytes32',
+      },
+    ],
+  },
+};
+
 const walletSendCallsEphemeralShortcuts: ShortcutType[] = [
   {
     key: 'wallet_sendCalls',
@@ -11,16 +59,32 @@ const walletSendCallsEphemeralShortcuts: ShortcutType[] = [
   },
 ];
 
-const walletSignEphemeralShortcuts: ShortcutType[] = [
+const walletSignOldSpecEphemeralShortcuts: ShortcutType[] = [
   {
-    key: 'wallet_sign',
+    key: 'Base Pay',
     data: {
-      message: 'Hello, world!',
+      version: '1.0',
+      type: '0x01',
+      data: BASE_PAY_DATA,
+    },
+  },
+];
+
+const walletSignNewSpecEphemeralShortcuts: ShortcutType[] = [
+  {
+    key: 'Base Pay',
+    data: {
+      version: '1.0',
+      request: {
+        type: '0x01',
+        data: BASE_PAY_DATA,
+      },
     },
   },
 ];
 
 export const ephemeralMethodShortcutsMap = {
   wallet_sendCalls: walletSendCallsEphemeralShortcuts,
-  wallet_sign: walletSignEphemeralShortcuts,
+  ['wallet_sign#old']: walletSignOldSpecEphemeralShortcuts,
+  ['wallet_sign#new']: walletSignNewSpecEphemeralShortcuts,
 };

--- a/examples/testapp/src/components/RpcMethods/shortcut/signMessageShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/signMessageShortcuts.ts
@@ -1,5 +1,102 @@
-import { ADDR_TO_FILL, EXAMPLE_MESSAGE } from './const';
 import { ShortcutType } from './ShortcutType';
+import { ADDR_TO_FILL, EXAMPLE_MESSAGE } from './const';
+
+const TYPED_DATA_V4_DATA = {
+  domain: {
+    chainId: '84532',
+    name: 'Ether Mail',
+    verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    version: '1',
+  },
+  message: {
+    contents: 'Hello, Bob!',
+    from: {
+      name: 'Cow',
+      wallets: [
+        '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+        '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
+      ],
+    },
+    to: [
+      {
+        name: 'Bob',
+        wallets: [
+          '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+          '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
+          '0xB0B0b0b0b0b0B000000000000000000000000000',
+        ],
+      },
+    ],
+  },
+  primaryType: 'Mail',
+  types: {
+    EIP712Domain: [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+    ],
+    Group: [
+      { name: 'name', type: 'string' },
+      { name: 'members', type: 'Person[]' },
+    ],
+    Mail: [
+      { name: 'from', type: 'Person' },
+      { name: 'to', type: 'Person[]' },
+      { name: 'contents', type: 'string' },
+    ],
+    Person: [
+      { name: 'name', type: 'string' },
+      { name: 'wallets', type: 'address[]' },
+    ],
+  },
+};
+
+const BASE_PAY_DATA = {
+  domain: {
+    chainId: 8453,
+    name: 'USDC',
+    verifyingContract: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+    version: '2',
+  },
+  message: {
+    from: ADDR_TO_FILL,
+    nonce: '0xbda37619d3004dba4ac2491022bc82b7df64c2f68e8a349422c71983a80d16ca',
+    to: '0xbc4c0191af73c4953b54f21ae0c74b31fc6cb21b',
+    validAfter: '0',
+    validBefore: '1914749767655',
+    value: '10000',
+  },
+  primaryType: 'ReceiveWithAuthorization',
+  types: {
+    ReceiveWithAuthorization: [
+      {
+        name: 'from',
+        type: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+      },
+      {
+        name: 'value',
+        type: 'uint256',
+      },
+      {
+        name: 'validAfter',
+        type: 'uint256',
+      },
+      {
+        name: 'validBefore',
+        type: 'uint256',
+      },
+      {
+        name: 'nonce',
+        type: 'bytes32',
+      },
+    ],
+  },
+};
 
 const personalSignShortcuts: ShortcutType[] = [
   {
@@ -77,56 +174,7 @@ const ethSignTypedDataV4Shortcuts: (chainId: number) => ShortcutType[] = (chainI
   {
     key: EXAMPLE_MESSAGE,
     data: {
-      message: {
-        domain: {
-          chainId,
-          name: 'Ether Mail',
-          verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
-          version: '1',
-        },
-        message: {
-          contents: 'Hello, Bob!',
-          from: {
-            name: 'Cow',
-            wallets: [
-              '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
-              '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
-            ],
-          },
-          to: [
-            {
-              name: 'Bob',
-              wallets: [
-                '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
-                '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
-                '0xB0B0b0b0b0b0B000000000000000000000000000',
-              ],
-            },
-          ],
-        },
-        primaryType: 'Mail',
-        types: {
-          EIP712Domain: [
-            { name: 'name', type: 'string' },
-            { name: 'version', type: 'string' },
-            { name: 'chainId', type: 'uint256' },
-            { name: 'verifyingContract', type: 'address' },
-          ],
-          Group: [
-            { name: 'name', type: 'string' },
-            { name: 'members', type: 'Person[]' },
-          ],
-          Mail: [
-            { name: 'from', type: 'Person' },
-            { name: 'to', type: 'Person[]' },
-            { name: 'contents', type: 'string' },
-          ],
-          Person: [
-            { name: 'name', type: 'string' },
-            { name: 'wallets', type: 'address[]' },
-          ],
-        },
-      },
+      message: TYPED_DATA_V4_DATA,
       address: ADDR_TO_FILL,
     },
   },
@@ -171,9 +219,81 @@ const ethSignTypedDataV4Shortcuts: (chainId: number) => ShortcutType[] = (chainI
   },
 ];
 
+const walletSignOldSpecShortcuts: ShortcutType[] = [
+  {
+    key: 'Base Pay',
+    data: {
+      version: '1.0',
+      type: '0x01',
+      address: ADDR_TO_FILL,
+      data: BASE_PAY_DATA,
+    },
+  },
+  {
+    key: 'Typed Data',
+    data: {
+      version: '1.0',
+      type: '0x01',
+      address: ADDR_TO_FILL,
+      data: TYPED_DATA_V4_DATA,
+    },
+  },
+  {
+    key: 'Personal Sign',
+    data: {
+      version: '1.0',
+      type: '0x45',
+      address: ADDR_TO_FILL,
+      data: {
+        message: 'Hello, World!',
+      },
+    },
+  },
+];
+
+const walletSignNewSpecShortcuts: ShortcutType[] = [
+  {
+    key: 'Base Pay',
+    data: {
+      version: '1.0',
+      request: {
+        type: '0x01',
+        data: BASE_PAY_DATA,
+      },
+      address: ADDR_TO_FILL,
+    },
+  },
+  {
+    key: 'Typed Data',
+    data: {
+      version: '1.0',
+      request: {
+        type: '0x01',
+        data: TYPED_DATA_V4_DATA,
+      },
+      address: ADDR_TO_FILL,
+    },
+  },
+  {
+    key: 'Personal Sign',
+    data: {
+      version: '1.0',
+      request: {
+        type: '0x45',
+        data: {
+          message: 'Hello, World!',
+        },
+      },
+      address: ADDR_TO_FILL,
+    },
+  },
+];
+
 export const signMessageShortcutsMap = (chainId: number) => ({
   personal_sign: personalSignShortcuts,
   eth_signTypedData_v1: ethSignTypedDataV1Shortcuts,
   eth_signTypedData_v3: ethSignTypedDataV3Shortcuts(chainId),
   eth_signTypedData_v4: ethSignTypedDataV4Shortcuts(chainId),
+  ['wallet_sign#old']: walletSignOldSpecShortcuts,
+  ['wallet_sign#new']: walletSignNewSpecShortcuts,
 });


### PR DESCRIPTION
### _Summary_

* added wallet_sign test cases in playground


#### Base Pay (712 Typed Data) Old Spec 
<img width="685" height="738" alt="Screenshot 2025-10-02 at 3 26 18 PM" src="https://github.com/user-attachments/assets/db57b969-d0a5-47a5-84ae-0c8805716d83" />


#### Base Pay (712 Typed Data) New Spec - Nested under request
<img width="719" height="765" alt="Screenshot 2025-10-02 at 3 26 30 PM" src="https://github.com/user-attachments/assets/81d1f5a0-59c2-48d8-b856-c8f3f5cbdbf6" />

#### Personal Sign Old Spec
<img width="542" height="187" alt="Screenshot 2025-10-02 at 3 26 01 PM" src="https://github.com/user-attachments/assets/01db6e4a-778a-4778-a4d8-ce51aed8aaa4" />

#### Personal Sign New Spec - Nested under request
<img width="535" height="212" alt="Screenshot 2025-10-02 at 3 26 42 PM" src="https://github.com/user-attachments/assets/ceaaf23d-39b7-437c-b473-b5af4d6e599d" />



### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
