### PR TITLE
feat: sub accounts config

### DIFF
--- a/examples/testapp/src/context/EIP1193ProviderContextProvider.test.tsx
+++ b/examples/testapp/src/context/EIP1193ProviderContextProvider.test.tsx
@@ -49,7 +49,9 @@ describe('EIP1193ProviderContextProvider', () => {
       setScwUrlAndSave: vi.fn(),
       setConfig: vi.fn(),
       subAccountsConfig: {
-        enableAutoSubAccounts: true,
+        creation: 'on-connect',
+        defaultAccount: 'sub',
+        funding: 'spend-permissions',
       },
       setSubAccountsConfig: vi.fn(),
     });
@@ -88,7 +90,9 @@ describe('EIP1193ProviderContextProvider', () => {
         walletUrl: 'https://keys-dev.coinbase.com/connect',
       },
       subAccounts: {
-        enableAutoSubAccounts: true,
+        creation: 'on-connect',
+        defaultAccount: 'sub',
+        funding: 'spend-permissions',
       },
     });
     expect(screen.getByTestId('sdk-exists')).toBeTruthy();
@@ -103,7 +107,9 @@ describe('EIP1193ProviderContextProvider', () => {
       scwUrl: 'https://keys-dev.coinbase.com/connect',
       config: { attribution: { dataSuffix: '0xtestattribution' } },
       subAccountsConfig: {
-        enableAutoSubAccounts: true,
+        creation: 'on-connect',
+        defaultAccount: 'sub',
+        funding: 'spend-permissions',
       },
       setSDKVersion: vi.fn(),
       setScwUrlAndSave: vi.fn(),
@@ -125,7 +131,9 @@ describe('EIP1193ProviderContextProvider', () => {
         walletUrl: 'https://keys-dev.coinbase.com/connect',
       },
       subAccounts: {
-        enableAutoSubAccounts: true,
+        creation: 'on-connect',
+        defaultAccount: 'sub',
+        funding: 'spend-permissions',
       },
     });
   });

--- a/examples/testapp/src/pages/auto-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/auto-sub-account/index.page.tsx
@@ -22,6 +22,7 @@ import {
   numberToHex,
   parseEther,
   parseUnits,
+  toHex,
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { baseSepolia } from 'viem/chains';
@@ -30,6 +31,7 @@ import { useEIP1193Provider } from '../../context/EIP1193ProviderContextProvider
 import { unsafe_generateOrLoadPrivateKey } from '../../utils/unsafe_generateOrLoadPrivateKey';
 
 type SignerType = 'cryptokey' | 'secp256k1';
+type SendMethod = 'eth_sendTransaction' | 'wallet_sendCalls';
 
 interface WalletConnectResponse {
   accounts: Array<{
@@ -38,12 +40,15 @@ interface WalletConnectResponse {
   }>;
 }
 
+const LOCAL_STORAGE_KEY = 'ba-playground:config';
+
 export default function AutoSubAccount() {
   const [accounts, setAccounts] = useState<string[]>([]);
   const [lastResult, setLastResult] = useState<string>();
   const [sendingAmounts, setSendingAmounts] = useState<Record<number, boolean>>({});
   const [sendingUsdcAmounts, setSendingUsdcAmounts] = useState<Record<string, boolean>>({});
   const [signerType, setSignerType] = useState<SignerType>('cryptokey');
+  const [sendMethod, setSendMethod] = useState<SendMethod>('eth_sendTransaction');
   const [walletConnectCapabilities, setWalletConnectCapabilities] = useState({
     siwe: false,
     addSubAccount: false,
@@ -51,16 +56,57 @@ export default function AutoSubAccount() {
   const { subAccountsConfig, setSubAccountsConfig, config, setConfig } = useConfig();
   const { provider } = useEIP1193Provider();
 
+  // Load persisted configs on mount
   useEffect(() => {
-    const stored = localStorage.getItem('signer-type');
-    if (stored !== null) {
-      setSignerType(stored as SignerType);
+    const stored = localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        
+        if (parsed.signerType) setSignerType(parsed.signerType);
+        if (parsed.sendMethod) setSendMethod(parsed.sendMethod);
+        if (parsed.walletConnectCapabilities) setWalletConnectCapabilities(parsed.walletConnectCapabilities);
+        
+        if (parsed.subAccountCreation) {
+          setSubAccountsConfig((prev) => ({ ...prev, creation: parsed.subAccountCreation }));
+        }
+        if (parsed.defaultAccount) {
+          setSubAccountsConfig((prev) => ({ ...prev, defaultAccount: parsed.defaultAccount }));
+        }
+        if (parsed.funding) {
+          setSubAccountsConfig((prev) => ({ ...prev, funding: parsed.funding }));
+        }
+        if (parsed.attribution) {
+          setConfig((prev) => ({ ...prev, attribution: parsed.attribution }));
+        }
+      } catch (e) {
+        console.error('Failed to parse stored config:', e);
+      }
     }
-  }, []);
+  }, [setSubAccountsConfig, setConfig]);
 
+  // Persist configs on change
   useEffect(() => {
-    localStorage.setItem('signer-type', signerType);
-  }, [signerType]);
+    const configToStore = {
+      signerType,
+      sendMethod,
+      walletConnectCapabilities,
+      subAccountCreation: subAccountsConfig?.creation,
+      defaultAccount: subAccountsConfig?.defaultAccount,
+      funding: subAccountsConfig?.funding,
+      attribution: config?.attribution,
+    };
+    
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(configToStore));
+  }, [
+    signerType,
+    sendMethod,
+    walletConnectCapabilities,
+    subAccountsConfig?.creation,
+    subAccountsConfig?.defaultAccount,
+    subAccountsConfig?.funding,
+    config?.attribution,
+  ]);
 
   useEffect(() => {
     const getSigner =
@@ -126,6 +172,36 @@ export default function AutoSubAccount() {
         ],
       });
       setLastResult(JSON.stringify(response, null, 2));
+    } catch (e) {
+      console.error('error', e);
+      setLastResult(JSON.stringify(e, null, 2));
+    }
+  };
+
+  const handlePersonalSign = async () => {
+    if (!provider || !accounts.length) return;
+
+    try {
+      const message = 'Hello from Coinbase Account SDK!';
+      const hexMessage = toHex(message);
+
+      const response = await provider.request({
+        method: 'personal_sign',
+        params: [hexMessage, accounts[0]],
+      });
+
+      const publicClient = createPublicClient({
+        chain: baseSepolia,
+        transport: http(),
+      });
+
+      const isValid = await publicClient.verifyMessage({
+        address: accounts[0] as `0x${string}`,
+        message,
+        signature: response as `0x${string}`,
+      });
+
+      setLastResult(`isValid: ${isValid}\n${response}`);
     } catch (e) {
       console.error('error', e);
       setLastResult(JSON.stringify(e, null, 2));
@@ -200,7 +276,7 @@ export default function AutoSubAccount() {
       // Add SIWE capability if selected
       if (walletConnectCapabilities.siwe) {
         capabilities.signInWithEthereum = {
-          chainId: 84532,
+          chainId: toHex(84532),
           nonce: Math.random().toString(36).substring(2, 15),
         };
       }
@@ -235,6 +311,13 @@ export default function AutoSubAccount() {
         params,
       })) as WalletConnectResponse;
       setLastResult(JSON.stringify(response, null, 2));
+
+      // Call eth_accounts to get and set the accounts after successful connection
+      const accountsResponse = await provider.request({
+        method: 'eth_accounts',
+        params: [],
+      });
+      setAccounts(accountsResponse as string[]);
     } catch (e) {
       console.error('error', e);
       setLastResult(JSON.stringify(e, null, 2));
@@ -249,17 +332,44 @@ export default function AutoSubAccount() {
       const to = '0x8d25687829d6b85d9e0020b8c89e3ca24de20a89';
       const value = parseEther(amount);
 
-      const response = await provider.request({
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            from: accounts[0],
-            to: to,
-            value: numberToHex(value),
-            data: '0x',
-          },
-        ],
-      });
+      let response;
+      if (sendMethod === 'eth_sendTransaction') {
+        response = await provider.request({
+          method: 'eth_sendTransaction',
+          params: [
+            {
+              from: accounts[0],
+              to: to,
+              value: numberToHex(value),
+              data: '0x',
+            },
+          ],
+        });
+      } else {
+        // wallet_sendCalls with paymaster support
+        response = await provider.request({
+          method: 'wallet_sendCalls',
+          params: [
+            {
+              version: '1.0',
+              chainId: numberToHex(baseSepolia.id),
+              from: accounts[0],
+              calls: [
+                {
+                  to: to,
+                  value: numberToHex(value),
+                  data: '0x',
+                },
+              ],
+              capabilities: {
+                paymasterService: {
+                  url: 'https://api.developer.coinbase.com/rpc/v1/base-sepolia/S-fOd2n2Oi4fl4e1Crm83XeDXZ7tkg8O',
+                },
+              },
+            },
+          ],
+        });
+      }
       setLastResult(JSON.stringify(response, null, 2));
     } catch (e) {
       console.error('error', e);
@@ -541,6 +651,23 @@ export default function AutoSubAccount() {
         </Button>
         <Button
           w="full"
+          onClick={handlePersonalSign}
+          isDisabled={!accounts.length}
+          bg="blue.500"
+          color="white"
+          border="1px solid"
+          borderColor="blue.500"
+          _hover={{ bg: 'blue.600', borderColor: 'blue.600' }}
+          _dark={{
+            bg: 'blue.600',
+            borderColor: 'blue.600',
+            _hover: { bg: 'blue.700', borderColor: 'blue.700' },
+          }}
+        >
+          personal_sign
+        </Button>
+        <Button
+          w="full"
           onClick={handleSignTypedData}
           isDisabled={!accounts.length}
           bg="blue.500"
@@ -572,6 +699,15 @@ export default function AutoSubAccount() {
         >
           wallet_connect
         </Button>
+        <FormControl>
+          <FormLabel>Send Method</FormLabel>
+          <RadioGroup value={sendMethod} onChange={(value: SendMethod) => setSendMethod(value)}>
+            <Stack direction="row">
+              <Radio value="eth_sendTransaction">eth_sendTransaction</Radio>
+              <Radio value="wallet_sendCalls">wallet_sendCalls (with paymaster)</Radio>
+            </Stack>
+          </RadioGroup>
+        </FormControl>
         <Box w="full" textAlign="left" fontSize="lg" fontWeight="bold">
           Send
         </Box>

--- a/examples/testapp/src/pages/auto-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/auto-sub-account/index.page.tsx
@@ -370,36 +370,53 @@ export default function AutoSubAccount() {
           </RadioGroup>
         </FormControl>
         <FormControl>
-          <FormLabel>Auto Sub-Accounts</FormLabel>
+          <FormLabel>Sub-Account Creation</FormLabel>
           <RadioGroup
-            value={(subAccountsConfig?.enableAutoSubAccounts || false).toString()}
+            value={subAccountsConfig?.creation || 'manual'}
             onChange={(value) =>
               setSubAccountsConfig((prev) => ({
                 ...prev,
-                enableAutoSubAccounts: value === 'true',
+                creation: value as 'on-connect' | 'manual',
               }))
             }
           >
             <Stack direction="row">
-              <Radio value="true">Enabled</Radio>
-              <Radio value="false">Disabled</Radio>
+              <Radio value="on-connect">On Connect</Radio>
+              <Radio value="manual">Manual</Radio>
             </Stack>
           </RadioGroup>
         </FormControl>
         <FormControl>
-          <FormLabel>Enable Auto Spend Permissions (Unstable)</FormLabel>
+          <FormLabel>Default Account</FormLabel>
           <RadioGroup
-            value={(subAccountsConfig?.unstable_enableAutoSpendPermissions ?? true).toString()}
+            value={subAccountsConfig?.defaultAccount || 'universal'}
             onChange={(value) =>
               setSubAccountsConfig((prev) => ({
                 ...prev,
-                unstable_enableAutoSpendPermissions: value === 'true',
+                defaultAccount: value as 'sub' | 'universal',
               }))
             }
           >
             <Stack direction="row">
-              <Radio value="true">Enabled</Radio>
-              <Radio value="false">Disabled</Radio>
+              <Radio value="sub">Sub</Radio>
+              <Radio value="universal">Universal</Radio>
+            </Stack>
+          </RadioGroup>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Funding Mode</FormLabel>
+          <RadioGroup
+            value={subAccountsConfig?.funding || 'spend-permissions'}
+            onChange={(value) =>
+              setSubAccountsConfig((prev) => ({
+                ...prev,
+                funding: value as 'spend-permissions' | 'manual',
+              }))
+            }
+          >
+            <Stack direction="row">
+              <Radio value="spend-permissions">Spend Permissions</Radio>
+              <Radio value="manual">Manual</Radio>
             </Stack>
           </RadioGroup>
         </FormControl>

--- a/examples/testapp/src/pages/auto-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/auto-sub-account/index.page.tsx
@@ -62,11 +62,12 @@ export default function AutoSubAccount() {
     if (stored) {
       try {
         const parsed = JSON.parse(stored);
-        
+
         if (parsed.signerType) setSignerType(parsed.signerType);
         if (parsed.sendMethod) setSendMethod(parsed.sendMethod);
-        if (parsed.walletConnectCapabilities) setWalletConnectCapabilities(parsed.walletConnectCapabilities);
-        
+        if (parsed.walletConnectCapabilities)
+          setWalletConnectCapabilities(parsed.walletConnectCapabilities);
+
         if (parsed.subAccountCreation) {
           setSubAccountsConfig((prev) => ({ ...prev, creation: parsed.subAccountCreation }));
         }
@@ -96,7 +97,7 @@ export default function AutoSubAccount() {
       funding: subAccountsConfig?.funding,
       attribution: config?.attribution,
     };
-    
+
     localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(configToStore));
   }, [
     signerType,

--- a/packages/account-sdk/src/core/provider/interface.ts
+++ b/packages/account-sdk/src/core/provider/interface.ts
@@ -85,19 +85,36 @@ export type Preference = {
   telemetry?: boolean;
 } & Record<string, unknown>;
 
+export type SubAccountCreationMode = 'on-connect' | 'manual';
+export type SubAccountDefaultAccount = 'sub' | 'universal';
+export type SubAccountFundingMode = 'spend-permissions' | 'manual';
+
 export type SubAccountOptions = {
-  /* Automatically create a subaccount for the user and use it for all transactions. */
-  enableAutoSubAccounts?: boolean;
+  /**
+   * Controls when sub accounts are created.
+   * - 'on-connect': Sub account is automatically created when connecting to the wallet
+   * - 'manual': Sub account must be manually created via wallet_addSubAccount
+   * @default 'manual'
+   */
+  creation?: SubAccountCreationMode;
+  /**
+   * Controls which account is used by default when no account is specified.
+   * - 'sub': Sub account is the default (first in accounts list)
+   * - 'universal': Universal account is the default (first in accounts list)
+   * @default 'universal'
+   */
+  defaultAccount?: SubAccountDefaultAccount;
+  /**
+   * Controls how sub accounts are funded.
+   * - 'spend-permissions': Routes through global account if no spend permissions exist, handles insufficient balance errors
+   * - 'manual': Direct execution from sub account without automatic fallbacks
+   * @default 'spend-permissions'
+   */
+  funding?: SubAccountFundingMode;
   /**
    * @returns The owner account that will be used to sign the subaccount transactions.
    */
   toOwnerAccount?: ToOwnerAccountFn;
-  /**
-   * This is an unstable feature that may change or be removed in future versions.
-   * When true, enables automatic spend permission requests and insufficient balance error handling for sub accounts.
-   * @default true
-   */
-  unstable_enableAutoSpendPermissions?: boolean;
 };
 
 export interface ConstructorOptions {

--- a/packages/account-sdk/src/core/telemetry/events/scw-signer.ts
+++ b/packages/account-sdk/src/core/telemetry/events/scw-signer.ts
@@ -8,6 +8,7 @@ export const logHandshakeStarted = ({
   method: string;
   correlationId: string | undefined;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_signer.handshake.started',
     {
@@ -15,7 +16,9 @@ export const logHandshakeStarted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -30,6 +33,7 @@ export const logHandshakeError = ({
   correlationId: string | undefined;
   errorMessage: string;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_signer.handshake.error',
     {
@@ -38,7 +42,9 @@ export const logHandshakeError = ({
       method,
       correlationId,
       errorMessage,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -51,6 +57,7 @@ export const logHandshakeCompleted = ({
   method: string;
   correlationId: string | undefined;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_signer.handshake.completed',
     {
@@ -58,7 +65,9 @@ export const logHandshakeCompleted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -71,6 +80,7 @@ export const logRequestStarted = ({
   method: string;
   correlationId: string | undefined;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_signer.request.started',
     {
@@ -78,7 +88,9 @@ export const logRequestStarted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -93,6 +105,7 @@ export const logRequestError = ({
   correlationId: string | undefined;
   errorMessage: string;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_signer.request.error',
     {
@@ -101,7 +114,9 @@ export const logRequestError = ({
       method,
       correlationId,
       errorMessage,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -114,6 +129,7 @@ export const logRequestCompleted = ({
   method: string;
   correlationId: string | undefined;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_signer.request.completed',
     {
@@ -121,7 +137,9 @@ export const logRequestCompleted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );

--- a/packages/account-sdk/src/core/telemetry/events/scw-sub-account.ts
+++ b/packages/account-sdk/src/core/telemetry/events/scw-sub-account.ts
@@ -8,6 +8,7 @@ export const logSubAccountRequestStarted = ({
   method: string;
   correlationId: string | undefined;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_sub_account.request.started',
     {
@@ -15,7 +16,9 @@ export const logSubAccountRequestStarted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -28,6 +31,7 @@ export const logSubAccountRequestCompleted = ({
   method: string;
   correlationId: string | undefined;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_sub_account.request.completed',
     {
@@ -35,7 +39,9 @@ export const logSubAccountRequestCompleted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -50,6 +56,7 @@ export const logSubAccountRequestError = ({
   correlationId: string | undefined;
   errorMessage: string;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_sub_account.request.error',
     {
@@ -58,7 +65,9 @@ export const logSubAccountRequestError = ({
       method,
       correlationId,
       errorMessage,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -71,6 +80,7 @@ export const logAddOwnerStarted = ({
   method: string;
   correlationId: string | undefined;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_sub_account.add_owner.started',
     {
@@ -78,7 +88,9 @@ export const logAddOwnerStarted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -91,6 +103,7 @@ export const logAddOwnerCompleted = ({
   method: string;
   correlationId: string | undefined;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_sub_account.add_owner.completed',
     {
@@ -98,7 +111,9 @@ export const logAddOwnerCompleted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -113,6 +128,7 @@ export const logAddOwnerError = ({
   correlationId: string | undefined;
   errorMessage: string;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_sub_account.add_owner.error',
     {
@@ -121,7 +137,9 @@ export const logAddOwnerError = ({
       method,
       correlationId,
       errorMessage,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -134,6 +152,7 @@ export const logInsufficientBalanceErrorHandlingStarted = ({
   method: string;
   correlationId: string | undefined;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_sub_account.insufficient_balance.error_handling.started',
     {
@@ -141,7 +160,9 @@ export const logInsufficientBalanceErrorHandlingStarted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -154,6 +175,7 @@ export const logInsufficientBalanceErrorHandlingCompleted = ({
   method: string;
   correlationId: string | undefined;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_sub_account.insufficient_balance.error_handling.completed',
     {
@@ -161,7 +183,9 @@ export const logInsufficientBalanceErrorHandlingCompleted = ({
       componentType: ComponentType.unknown,
       method,
       correlationId,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );
@@ -176,6 +200,7 @@ export const logInsufficientBalanceErrorHandlingError = ({
   correlationId: string | undefined;
   errorMessage: string;
 }) => {
+  const config = store.subAccountsConfig.get();
   logEvent(
     'scw_sub_account.insufficient_balance.error_handling.error',
     {
@@ -184,7 +209,9 @@ export const logInsufficientBalanceErrorHandlingError = ({
       method,
       correlationId,
       errorMessage,
-      enableAutoSubAccounts: store.subAccountsConfig.get()?.enableAutoSubAccounts,
+      subAccountCreation: config?.creation,
+      subAccountDefaultAccount: config?.defaultAccount,
+      subAccountFunding: config?.funding,
     },
     AnalyticsEventImportance.high
   );

--- a/packages/account-sdk/src/core/telemetry/logEvent.ts
+++ b/packages/account-sdk/src/core/telemetry/logEvent.ts
@@ -63,7 +63,9 @@ type CCAEventData = {
   errorMessage?: string;
   dialogContext?: string;
   dialogAction?: string;
-  enableAutoSubAccounts?: boolean;
+  subAccountCreation?: 'on-connect' | 'manual';
+  subAccountDefaultAccount?: 'sub' | 'universal';
+  subAccountFunding?: 'spend-permissions' | 'manual';
   // Payment-specific attributes
   amount?: string;
   testnet?: boolean;

--- a/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.test.ts
+++ b/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.test.ts
@@ -116,9 +116,11 @@ describe('Ephemeral methods', () => {
 });
 
 describe('Auto sub account', () => {
-  it('call handshake without method when enableAutoSubAccounts is true', async () => {
+  it('call handshake without method when creation is on-connect', async () => {
     vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
-      enableAutoSubAccounts: true,
+      creation: 'on-connect',
+      defaultAccount: 'sub',
+      funding: 'spend-permissions',
     });
 
     await provider.request({ method: 'eth_requestAccounts' });

--- a/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
+++ b/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
@@ -95,8 +95,19 @@ export class BaseAccountProvider extends ProviderEventEmitter implements Provide
             break;
           }
           case 'wallet_connect': {
+            console.log(
+              '[BaseAccountProvider wallet_connect] Handling wallet_connect, not connected yet'
+            );
+            console.log('[BaseAccountProvider wallet_connect] Original args:', args);
             await this.signer.handshake({ method: 'handshake' }); // exchange session keys
+            console.log(
+              '[BaseAccountProvider wallet_connect] Handshake complete, calling signer.request'
+            );
             const result = await this.signer.request(args); // send diffie-hellman encrypted request
+            console.log(
+              '[BaseAccountProvider wallet_connect] Signer.request complete, result:',
+              result
+            );
             return result as T;
           }
           case 'wallet_switchEthereumChain': {

--- a/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
+++ b/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
@@ -95,19 +95,8 @@ export class BaseAccountProvider extends ProviderEventEmitter implements Provide
             break;
           }
           case 'wallet_connect': {
-            console.log(
-              '[BaseAccountProvider wallet_connect] Handling wallet_connect, not connected yet'
-            );
-            console.log('[BaseAccountProvider wallet_connect] Original args:', args);
             await this.signer.handshake({ method: 'handshake' }); // exchange session keys
-            console.log(
-              '[BaseAccountProvider wallet_connect] Handshake complete, calling signer.request'
-            );
             const result = await this.signer.request(args); // send diffie-hellman encrypted request
-            console.log(
-              '[BaseAccountProvider wallet_connect] Signer.request complete, result:',
-              result
-            );
             return result as T;
           }
           case 'wallet_switchEthereumChain': {

--- a/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.test.ts
+++ b/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.test.ts
@@ -147,8 +147,9 @@ describe('createProvider', () => {
       const params: CreateProviderOptions = {
         subAccounts: {
           toOwnerAccount: mockToOwnerAccount,
-          // @ts-expect-error - enableAutoSubAccounts is not officially supported yet
-          enableAutoSubAccounts: true,
+          creation: 'on-connect',
+          defaultAccount: 'sub',
+          funding: 'spend-permissions',
         },
       };
 
@@ -157,16 +158,16 @@ describe('createProvider', () => {
       expect(mockValidateSubAccount).toHaveBeenCalledWith(mockToOwnerAccount);
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: mockToOwnerAccount,
-        enableAutoSubAccounts: true,
-        unstable_enableAutoSpendPermissions: true,
+        creation: 'on-connect',
+        defaultAccount: 'sub',
+        funding: 'spend-permissions',
       });
     });
 
     it('should handle partial sub-account configuration', () => {
       const params: CreateProviderOptions = {
         subAccounts: {
-          // @ts-expect-error - enableAutoSubAccounts is not officially supported yet
-          enableAutoSubAccounts: true,
+          creation: 'on-connect',
         },
       };
 
@@ -175,8 +176,9 @@ describe('createProvider', () => {
       expect(mockValidateSubAccount).not.toHaveBeenCalled();
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: undefined,
-        enableAutoSubAccounts: true,
-        unstable_enableAutoSpendPermissions: true,
+        creation: 'on-connect',
+        defaultAccount: 'universal',
+        funding: 'spend-permissions',
       });
     });
 
@@ -189,19 +191,20 @@ describe('createProvider', () => {
 
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: undefined,
-        enableAutoSubAccounts: undefined,
-        unstable_enableAutoSpendPermissions: true,
+        creation: 'manual',
+        defaultAccount: 'universal',
+        funding: 'spend-permissions',
       });
     });
 
-    it('should set unstable_enableAutoSpendPermissions when provided', () => {
+    it('should set funding mode when provided', () => {
       const mockToOwnerAccount = vi.fn();
       const params: CreateProviderOptions = {
         subAccounts: {
           toOwnerAccount: mockToOwnerAccount,
-          // @ts-expect-error - enableAutoSubAccounts is not officially supported yet
-          enableAutoSubAccounts: true,
-          unstable_enableAutoSpendPermissions: true,
+          creation: 'on-connect',
+          defaultAccount: 'sub',
+          funding: 'manual',
         },
       };
 
@@ -210,12 +213,13 @@ describe('createProvider', () => {
       expect(mockValidateSubAccount).toHaveBeenCalledWith(mockToOwnerAccount);
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: mockToOwnerAccount,
-        enableAutoSubAccounts: true,
-        unstable_enableAutoSpendPermissions: true,
+        creation: 'on-connect',
+        defaultAccount: 'sub',
+        funding: 'manual',
       });
     });
 
-    it('should default unstable_enableAutoSpendPermissions to true when not provided', () => {
+    it('should apply default values when config options not provided', () => {
       const mockToOwnerAccount = vi.fn();
       const params: CreateProviderOptions = {
         subAccounts: {
@@ -227,17 +231,20 @@ describe('createProvider', () => {
 
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: mockToOwnerAccount,
-        enableAutoSubAccounts: undefined,
-        unstable_enableAutoSpendPermissions: true,
+        creation: 'manual',
+        defaultAccount: 'universal',
+        funding: 'spend-permissions',
       });
     });
 
-    it('should default unstable_enableAutoSpendPermissions to true when explicitly set to undefined', () => {
+    it('should use default values when explicitly set to undefined', () => {
       const mockToOwnerAccount = vi.fn();
       const params: CreateProviderOptions = {
         subAccounts: {
           toOwnerAccount: mockToOwnerAccount,
-          unstable_enableAutoSpendPermissions: undefined,
+          creation: undefined,
+          defaultAccount: undefined,
+          funding: undefined,
         },
       };
 
@@ -245,8 +252,9 @@ describe('createProvider', () => {
 
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: mockToOwnerAccount,
-        enableAutoSubAccounts: undefined,
-        unstable_enableAutoSpendPermissions: true,
+        creation: 'manual',
+        defaultAccount: 'universal',
+        funding: 'spend-permissions',
       });
     });
   });
@@ -390,8 +398,9 @@ describe('createProvider', () => {
         },
         subAccounts: {
           toOwnerAccount: mockToOwnerAccount,
-          // @ts-expect-error - enableAutoSubAccounts is not officially supported yet
-          enableAutoSubAccounts: true,
+          creation: 'on-connect',
+          defaultAccount: 'sub',
+          funding: 'spend-permissions',
         },
         paymasterUrls: {
           1: 'https://paymaster.example.com',
@@ -404,8 +413,9 @@ describe('createProvider', () => {
       expect(mockValidateSubAccount).toHaveBeenCalledWith(mockToOwnerAccount);
       expect(mockStore.subAccountsConfig.set).toHaveBeenCalledWith({
         toOwnerAccount: mockToOwnerAccount,
-        enableAutoSubAccounts: true,
-        unstable_enableAutoSpendPermissions: true,
+        creation: 'on-connect',
+        defaultAccount: 'sub',
+        funding: 'spend-permissions',
       });
 
       // Check store configuration

--- a/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
+++ b/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
@@ -19,7 +19,7 @@ import { getInjectedProvider } from './getInjectedProvider.js';
 
 export type CreateProviderOptions = Partial<AppMetadata> & {
   preference?: Preference;
-  subAccounts?: Omit<SubAccountOptions, 'enableAutoSubAccounts'>;
+  subAccounts?: SubAccountOptions;
   paymasterUrls?: Record<number, string>;
 };
 
@@ -49,10 +49,9 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
 
   store.subAccountsConfig.set({
     toOwnerAccount: params.subAccounts?.toOwnerAccount,
-    // @ts-expect-error - enableSubAccounts is not officially supported yet
-    enableAutoSubAccounts: params.subAccounts?.enableAutoSubAccounts,
-    unstable_enableAutoSpendPermissions:
-      params.subAccounts?.unstable_enableAutoSpendPermissions ?? true,
+    creation: params.subAccounts?.creation ?? 'manual',
+    defaultAccount: params.subAccounts?.defaultAccount ?? 'universal',
+    funding: params.subAccounts?.funding ?? 'spend-permissions',
   });
 
   //  ====================================================================

--- a/packages/account-sdk/src/sign/base-account/utils.ts
+++ b/packages/account-sdk/src/sign/base-account/utils.ts
@@ -123,6 +123,9 @@ export function injectRequestCapabilities<T extends RequestArguments>(
       throw standardErrors.rpc.invalidParams();
     }
 
+    // Merge capabilities: injected capabilities first, then request capabilities
+    // This ensures that if the request doesn't have a capability (e.g., addSubAccount),
+    // it gets injected. If the request already has it, the request's version takes precedence.
     requestCapabilities = {
       ...capabilities,
       ...requestCapabilities,
@@ -148,7 +151,7 @@ export async function initSubAccountConfig() {
 
   const capabilities: WalletConnectRequest['params'][0]['capabilities'] = {};
 
-  if (config.enableAutoSubAccounts) {
+  if (config.creation === 'on-connect') {
     // Get the owner account
     const { account: owner } = config.toOwnerAccount
       ? await config.toOwnerAccount()
@@ -171,8 +174,9 @@ export async function initSubAccountConfig() {
     };
   }
 
-  // Store the owner account and capabilities in the non-persisted config
+  // Merge capabilities with existing config (don't overwrite the other properties!)
   store.subAccountsConfig.set({
+    ...config,
     capabilities,
   });
 }


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
https://linear.app/coinbase/issue/BA-2882/expose-enableautosubaccounts-again

### Breaking Changes

**Old Configuration (Removed):**
```typescript
{
  subAccounts: {
    enableAutoSubAccounts?: boolean;
    unstable_enableAutoSpendPermissions?: boolean;
  }
}
```

**New Configuration:**
```typescript
{
  subAccounts: {
    creation?: 'on-connect' | 'manual';              // default: 'manual'
    defaultAccount?: 'sub' | 'universal';            // default: 'universal'
    funding?: 'spend-permissions' | 'manual';        // default: 'spend-permissions'
    toOwnerAccount?: ToOwnerAccountFn;
  }
}
```

### Configuration Options

**`creation`** - Controls when sub-accounts are created:
- `'on-connect'`: Automatically creates a sub-account on wallet connection (automatically injects `addSubAccount` capability to `wallet_connect`)
- `'manual'`: Requires explicit `wallet_addSubAccount` call

**`defaultAccount`** - Controls account ordering:
- `'sub'`: Sub-account is first in accounts array (default for transactions)
- `'universal'`: Universal account is first in accounts array

**`funding`** - Controls sub-account funding behavior:
- `'spend-permissions'`: Routes through universal account if no spend permissions exist, handles insufficient balance errors automatically
- `'manual'`: Direct execution from sub-account without automatic fallbacks

### Migration Guide

```typescript
// Old → New
enableAutoSubAccounts: true → { creation: 'on-connect', defaultAccount: 'sub' }
enableAutoSubAccounts: false → { creation: 'manual', defaultAccount: 'universal' }
unstable_enableAutoSpendPermissions: true → { funding: 'spend-permissions' }
unstable_enableAutoSpendPermissions: false → { funding: 'manual' }
```

### Implementation Details

- Automatic `addSubAccount` capability injection for `wallet_connect` when `creation: 'on-connect'`
- Works in both connected and not-connected states
- Updated telemetry to track individual config dimensions
- All 775 tests passing

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
