### PR TITLE
Update playground placeholder comments

### DIFF
--- a/examples/testapp/src/pages/pay-playground/constants/playground.ts
+++ b/examples/testapp/src/pages/pay-playground/constants/playground.ts
@@ -41,7 +41,7 @@ export const DEFAULT_GET_PAYMENT_STATUS_CODE = `import { base } from '@base-org/
 
 try {
   const result = await base.getPaymentStatus({
-    id: '0x...', // Automatically filled with your recent transaction
+    id: '0x...', // Replace with a transaction ID
     testnet: true
   })
   

--- a/examples/testapp/src/pages/subscribe-playground/constants/playground.ts
+++ b/examples/testapp/src/pages/subscribe-playground/constants/playground.ts
@@ -34,7 +34,7 @@ export const DEFAULT_GET_SUBSCRIPTION_STATUS_CODE = `import { base } from '@base
 
 try {
   const result = await base.subscription.getStatus({
-    id: '0x...', // Automatically filled with your recent subscription
+    id: '0x...', // Replace with a subscription ID
     testnet: true
   })
   


### PR DESCRIPTION
### _Summary_

Updated placeholder comments in playground constants to only show "Automatically filled" after automatically filling


### _How did you test your changes?_

manually tested - it looks right in playground


<img width="893" height="389" alt="Screenshot 2025-10-13 at 12 55 23 PM" src="https://github.com/user-attachments/assets/f75217e0-e8d8-4fd7-bd3c-fd8501dd428d" />


<img width="895" height="394" alt="Screenshot 2025-10-13 at 12 55 39 PM" src="https://github.com/user-attachments/assets/dd72094f-b4c3-4a69-9060-34e8159249b0" />
