### PR TITLE
fix: add error handling to getInjectedProvider

### DIFF
--- a/packages/account-sdk/src/core/telemetry/events/provider.ts
+++ b/packages/account-sdk/src/core/telemetry/events/provider.ts
@@ -62,3 +62,21 @@ export const logRequestResponded = ({
     AnalyticsEventImportance.high
   );
 };
+
+export const logGetInjectedProviderError = ({
+  errorMessage,
+}: {
+  errorMessage: string;
+}) => {
+  logEvent(
+    'provider.getInjectedProvider.error',
+    {
+      action: ActionType.error,
+      componentType: ComponentType.unknown,
+      method: 'getInjectedProvider',
+      signerType: 'base-account',
+      errorMessage,
+    },
+    AnalyticsEventImportance.high
+  );
+};

--- a/packages/account-sdk/src/interface/builder/core/getInjectedProvider.test.ts
+++ b/packages/account-sdk/src/interface/builder/core/getInjectedProvider.test.ts
@@ -1,8 +1,8 @@
-import { logGetInjectedProviderError } from ':core/telemetry/events/provider';
+import { logGetInjectedProviderError } from ':core/telemetry/events/provider.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getInjectedProvider } from './getInjectedProvider.js';
 
-vi.mock(':core/telemetry/events/provider', () => ({
+vi.mock(':core/telemetry/events/provider.js', () => ({
   logGetInjectedProviderError: vi.fn(),
 }));
 

--- a/packages/account-sdk/src/interface/builder/core/getInjectedProvider.ts
+++ b/packages/account-sdk/src/interface/builder/core/getInjectedProvider.ts
@@ -1,6 +1,6 @@
 import { ProviderInterface } from ':core/provider/interface.js';
-import { logGetInjectedProviderError } from ':core/telemetry/events/provider';
-import { parseErrorMessageFromAny } from ':core/telemetry/utils';
+import { logGetInjectedProviderError } from ':core/telemetry/events/provider.js';
+import { parseErrorMessageFromAny } from ':core/telemetry/utils.js';
 
 declare global {
   interface Window {


### PR DESCRIPTION
## Summary

This PR adds  error handling to the `getInjectedProvider` function to prevent it from throwing errors when accessing `window.ethereum` or `window.top.ethereum`. This is an issue when running the SDK within an iframe, where window is not accessible. In this case, we should return null for `getInjectedProvider` and proceed with the BaseAccountProvider

## Changes

- **getInjectedProvider.ts**: Wrapped the function in a try-catch block that:
  - Returns `null` instead of throwing when window access fails
  - Logs  the error
 

### _How did you test your changes?_

- Added unit tests