### PR TITLE
fix: error caused by deep destructuring in constructor

### DIFF
--- a/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
+++ b/packages/account-sdk/src/interface/builder/core/BaseAccountProvider.ts
@@ -26,11 +26,12 @@ export class BaseAccountProvider extends ProviderEventEmitter implements Provide
   private readonly communicator: Communicator;
   private readonly signer: Signer;
 
-  constructor({
-    metadata,
-    preference: { walletUrl, ...preference },
-  }: Readonly<ConstructorOptions>) {
+  constructor(options: Readonly<ConstructorOptions>) {
     super();
+    const {
+      metadata,
+      preference: { walletUrl, ...preference },
+    } = options;
     this.communicator = new Communicator({
       url: walletUrl,
       metadata,


### PR DESCRIPTION
### *Summary*

moved the deep destructuring of `...preference` inside the constructor body to avoid TS error **TS2334** when using `Readonly<ConstructorOptions>`.
this change keeps the logic identical but resolves the type issue during compilation.

### *How did you test your changes?*

verified that the project builds without TS errors and that the affected class behaves the same during runtime.
