### PR TITLE
Fix validation bug with malformed decimal amounts

### DIFF
--- a/packages/account-sdk/src/interface/payment/utils/validation.test.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.test.ts
@@ -20,6 +20,13 @@ describe('validateStringAmount', () => {
     );
   });
 
+  it('should reject malformed decimal amounts', () => {
+    expect(() => validateStringAmount('10.', 6)).toThrow('Invalid amount: must be a valid decimal number');
+    expect(() => validateStringAmount('.5', 6)).toThrow('Invalid amount: must be a valid decimal number');
+    expect(() => validateStringAmount('1.2.3', 6)).toThrow('Invalid amount: multiple decimal points not allowed');
+    expect(() => validateStringAmount('10..5', 6)).toThrow('Invalid amount: multiple decimal points not allowed');
+  });
+
   it('should reject non-string amounts', () => {
     expect(() => validateStringAmount(10 as any, 6)).toThrow('Invalid amount: must be a string');
   });

--- a/packages/account-sdk/src/interface/payment/utils/validation.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.ts
@@ -11,6 +11,16 @@ export function validateStringAmount(amount: string, maxDecimals: number): void 
     throw new Error('Invalid amount: must be a string');
   }
 
+  // Reject multiple decimal points (e.g., "1.2.3" or "10..5")
+  if ((amount.match(/\./g) || []).length > 1) {
+    throw new Error('Invalid amount: multiple decimal points not allowed');
+  }
+
+  // Reject trailing or leading decimal points (e.g., "10." or ".5")
+  if (amount.startsWith('.') || amount.endsWith('.')) {
+    throw new Error('Invalid amount: must be a valid decimal number');
+  }
+
   const numAmount = parseFloat(amount);
 
   if (isNaN(numAmount)) {


### PR DESCRIPTION
## Issue

The amount validation was accepting malformed inputs like `"1.2.3"` or `"10..5"` because it only checked the parsed value, not the format itself. This meant parseFloat would silently misinterpret them:

- `"1.2.3"` → parsed as `1.2` (user loses $0.03)
- `"10..5"` → parsed as `10` (user loses $0.50)

This could cause users to accidentally send the wrong payment amount.

## Changes

Added validation checks before parseFloat to reject:
- Multiple decimal points (`"1.2.3"`, `"10..5"`)
- Trailing decimals (`"10."`)
- Leading decimals (`".5"`)

## Tests

Added test cases covering all the malformed input scenarios.