### PR TITLE
docs: fix typo and incorrect import path in documentation

### DIFF
--- a/packages/account-sdk/README.md
+++ b/packages/account-sdk/README.md
@@ -127,7 +127,7 @@
 
 ## Script Tag Usage
 
-Base Accunt can be used directly in HTML pages via a script tag, without any build tools:
+Base Account can be used directly in HTML pages via a script tag, without any build tools:
 
 ```html
 <!-- Via unpkg -->

--- a/packages/account-sdk/src/interface/payment/README.md
+++ b/packages/account-sdk/src/interface/payment/README.md
@@ -26,7 +26,7 @@ if (payment.success) {
 You can check the status of a payment using the transaction ID returned from the pay function:
 
 ```typescript
-import { getPaymentStatus } from '@base/account-sdk';
+import { getPaymentStatus } from '@base-org/account';
 
 // Check payment status
 const status = await getPaymentStatus({


### PR DESCRIPTION
Fixed two documentation issues:

1. **Typo in packages/account-sdk/README.md (line 130)**
   - Changed "Base Accunt" to "Base Account"

2. **Incorrect import path in packages/account-sdk/src/interface/payment/README.md (line 29)**
   - Changed `@base/account-sdk` to `@base-org/account`
   - This was causing the example code to fail when users copy-pasted it

The second fix is more critical as it prevents users from getting import errors when following the documentation examples.