### PR TITLE
Add Convenience Interface and Webhook Auto-Generation for Prolink Playground

### DIFF
--- a/examples/testapp/src/pages/prolink-playground/index.page.tsx
+++ b/examples/testapp/src/pages/prolink-playground/index.page.tsx
@@ -25,7 +25,7 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import { QRCodeSVG } from 'qrcode.react';
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { encodeFunctionData, type Address } from 'viem';
 
 // Token configuration
@@ -119,11 +119,12 @@ export default function ProlinkPlayground() {
     JSON.stringify(
       {
         dataCallback: {
-          url: 'https://example.com/callback',
-          events: ['initiated', 'preSigning', 'postSigning'],
-          metadata: {
-            customField: 'customValue',
-          },
+          callbackURL: 'https://example.com/callback',
+          events: [
+            { type: 'initiated', context: { orderId: '123' } },
+            { type: 'preSign', context: { shippingTier: 'express' } },
+            { type: 'postSign', context: { webhookTag: 'after' } },
+          ],
         },
       },
       null,
@@ -198,11 +199,12 @@ export default function ProlinkPlayground() {
           // Update capabilities JSON with the webhook URL
           const capabilities = {
             dataCallback: {
-              url: `https://webhook.site/${data.uuid}`,
-              events: ['initiated', 'preSigning', 'postSigning'],
-              metadata: {
-                customField: 'customValue',
-              },
+              callbackURL: `https://webhook.site/${data.uuid}`,
+              events: [
+                { type: 'initiated', context: { orderId: '123' } },
+                { type: 'preSign', context: { shippingTier: 'express' } },
+                { type: 'postSign', context: { webhookTag: 'after' } },
+              ],
             },
           };
           setCapabilitiesJson(JSON.stringify(capabilities, null, 2));


### PR DESCRIPTION
## What changed? Why?

Added convenience interface for generating calldata and auto-generation of webhook.site URLs for testing in the Prolink Playground.

**Calldata Generation Interface:**
- Simple Mode toggle for user-friendly transaction creation
- Token selector (USDC/ETH) with automatic calldata generation
- Wei-based amount input field for precise control
- Recipient address field
- Auto-encoding of ERC20 transfer calldata using viem's `encodeFunctionData`
- Dynamic updates when fields change

**Webhook Auto-Generation:**
- Automatic generation of webhook.site URLs when capabilities are enabled
- Automatic population of capabilities JSON with webhook URL and event configuration
- Toast notifications for successful generation and errors

**Additional:**
- Token configuration constants (USDC, ETH) with multi-chain addresses
- ERC20 transfer ABI constant
- Simplified interface by removing SpendPermission example fields

## How was this tested?

Lint, format, and typecheck all passed successfully. Test suite has a pre-existing failure in Dialog component tests unrelated to these changes. All testapp tests passed.

## How can reviewers manually test these changes?

**Testing Simple Mode Calldata Generation:**
1. Navigate to the Prolink Playground in the testapp
2. Observe "Simple Mode" toggle is enabled by default
3. Select a token (USDC or ETH) from the dropdown
4. Enter a wei amount (e.g., 10000 for USDC = $0.01)
5. Enter a recipient address
6. Observe the "To Address" and "Data" fields auto-update below
7. Generate a prolink and verify the transaction parameters are correct

**Testing Webhook Auto-Generation:**
1. In the capabilities section, check the "Include Capabilities" checkbox
2. Observe a webhook.site URL is automatically generated and populated
3. Verify the toast notification confirms successful webhook generation
4. Generate a prolink and verify the webhook URL is included
5. Visit the webhook.site URL to monitor incoming webhook events

**Testing Advanced Mode:**
1. Toggle off "Simple Mode"
2. Verify direct access to raw calldata fields (To Address, Data, Value)
3. Enter custom hex values and generate prolinks

## Demo/screenshots


https://github.com/user-attachments/assets/7423ff28-f467-473c-a64c-2502c483621a


