### PR TITLE
Default to testnet on prolink playground

### DIFF
--- a/examples/testapp/src/pages/prolink-playground/index.page.tsx
+++ b/examples/testapp/src/pages/prolink-playground/index.page.tsx
@@ -78,10 +78,10 @@ export default function ProlinkPlayground() {
   const [methodType, setMethodType] = useState<'wallet_sendCalls' | 'generic'>('wallet_sendCalls');
 
   // Common fields
-  const [chainId, setChainId] = useState('8453'); // Base mainnet
+  const [chainId, setChainId] = useState('84532'); // Base Sepolia (testnet)
 
   // wallet_sendCalls fields
-  const [callsTo, setCallsTo] = useState('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'); // USDC on Base
+  const [callsTo, setCallsTo] = useState('0x036CbD53842c5426634e7929541eC2318f3dCF7e'); // USDC on Base Sepolia
   const [callsData, setCallsData] = useState(
     '0xa9059cbb000000000000000000000000fe21034794a5a574b94fe4fdfd16e005f1c96e5100000000000000000000000000000000000000000000000000000000004c4b40'
   ); // ERC20 transfer


### PR DESCRIPTION
## What changed? Why?

Updated prolink playground to default to Base Sepolia (testnet) instead of Base mainnet. This includes:
- Changed default chain ID from 8453 to 84532
- Updated default USDC contract address to Base Sepolia USDC (0x036CbD53842c5426634e7929541eC2318f3dCF7e)

This change makes the playground safer for testing by preventing accidental mainnet transactions.

## How was this tested?

Test coverage:
- All testapp tests pass (yarn test --run in examples/testapp)
- Linting passes (yarn lint)
- Formatting passes (yarn format)
- Type checking passes (yarn typecheck)

Note: Pre-existing Dialog.test.tsx failures in account-sdk package are unrelated to these changes.

## How can reviewers manually test these changes?

1. Run the testapp locally: `yarn dev` from the testapp directory
2. Navigate to the prolink playground page
3. Verify the chain ID dropdown defaults to "84532" (Base Sepolia)
4. Verify the "To Address" field defaults to "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
5. Generate a prolink and verify it uses testnet parameters

## Demo/screenshots


