### PR TITLE
chore: bump version to 2.5.1

### DIFF
--- a/packages/account-sdk/package.json
+++ b/packages/account-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@base-org/account",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Base Account SDK",
   "keywords": [
     "base",


### PR DESCRIPTION
Version bump from 2.5.0 to 2.5.1 for @base-org/account package