### PR TITLE
fix(account-sdk): validate capabilities filter hex strings

### DIFF
--- a/packages/account-sdk/src/sign/base-account/utils.test.ts
+++ b/packages/account-sdk/src/sign/base-account/utils.test.ts
@@ -1,22 +1,22 @@
 import { store } from ':store/store.js';
 import { hashTypedData, hexToBigInt, numberToHex } from 'viem';
 import {
-  SpendPermissionBatch,
-  addSenderToRequest,
-  appendWithoutDuplicates,
-  assertFetchPermissionsRequest,
-  assertGetCapabilitiesParams,
-  assertParamsChainId,
-  createSpendPermissionBatchMessage,
-  createWalletSendCallsRequest,
-  fillMissingParamsForFetchPermissions,
-  getCachedWalletConnectResponse,
-  getSenderFromRequest,
-  initSubAccountConfig,
-  injectRequestCapabilities,
-  isSendCallsParams,
-  prependWithoutDuplicates,
-  requestHasCapability,
+    SpendPermissionBatch,
+    addSenderToRequest,
+    appendWithoutDuplicates,
+    assertFetchPermissionsRequest,
+    assertGetCapabilitiesParams,
+    assertParamsChainId,
+    createSpendPermissionBatchMessage,
+    createWalletSendCallsRequest,
+    fillMissingParamsForFetchPermissions,
+    getCachedWalletConnectResponse,
+    getSenderFromRequest,
+    initSubAccountConfig,
+    injectRequestCapabilities,
+    isSendCallsParams,
+    prependWithoutDuplicates,
+    requestHasCapability,
 } from './utils.js';
 
 // Valid Ethereum addresses for testing
@@ -151,6 +151,7 @@ describe('assertGetCapabilitiesParams', () => {
     expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1', 123]])).toThrow();
     expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1', null]])).toThrow();
     expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['abc123']])).toThrow();
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0xgg']])).toThrow();
   });
 
   it('should not throw for valid parameters with filter array', () => {

--- a/packages/account-sdk/src/sign/base-account/utils.ts
+++ b/packages/account-sdk/src/sign/base-account/utils.ts
@@ -1,4 +1,4 @@
-import { PublicClient, WalletSendCallsParameters, hexToBigInt, isAddress } from 'viem';
+import { PublicClient, WalletSendCallsParameters, hexToBigInt, isAddress, isHex } from 'viem';
 
 import { InsufficientBalanceErrorData } from ':core/error/errors.js';
 import { Hex, keccak256, numberToHex, slice, toHex } from 'viem';
@@ -98,7 +98,7 @@ export function assertGetCapabilitiesParams(
     }
 
     for (const param of params[1]) {
-      if (typeof param !== 'string' || !param.startsWith('0x')) {
+      if (typeof param !== 'string' || !isHex(param)) {
         throw standardErrors.rpc.invalidParams();
       }
     }


### PR DESCRIPTION
### _Summary_

This PR tightens input validation in assertGetCapabilitiesParams to ensure the optional filter array contains valid hex strings.

Previously, filter entries were accepted if they were strings that started with 0x (e.g. 0xgg would pass).
Now, filter entries must pass viem’s isHex check.

Added a regression test to ensure invalid hex values like 0xgg are rejected.

### _How did you test your changes?_

Updated/added unit test coverage in packages/account-sdk/src/sign/base-account/utils.test.ts (added case for invalid filter entry 0xgg).

How to verify: yarn workspace @base-org/account test
