### PR TITLE
fix: eth_sendTransaction returns 65-byte signature instead of tx hash for global account

### DIFF
--- a/packages/account-sdk/src/sign/base-account/Signer.test.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.test.ts
@@ -17,6 +17,7 @@ import {
 } from ':util/cipher.js';
 import { fetchRPCRequest } from ':util/provider.js';
 import { HttpRequestError, numberToHex } from 'viem';
+import { waitForCallsStatus } from 'viem/actions';
 import { SCWKeyManager } from './SCWKeyManager.js';
 import { Signer } from './Signer.js';
 import { createSubAccountSigner } from './utils/createSubAccountSigner.js';
@@ -64,6 +65,12 @@ vi.mock('../../kms/crypto-key/index.js', () => ({
 
 vi.mock(':util/provider');
 vi.mock(':store/chain-clients/utils');
+vi.mock('viem/actions', () => ({
+  waitForCallsStatus: vi.fn().mockResolvedValue({
+    status: 'success',
+    receipts: [{ transactionHash: `0x${'a'.repeat(64)}` }],
+  }),
+}));
 vi.mock('./SCWKeyManager');
 vi.mock(':core/communicator/Communicator', () => ({
   Communicator: vi.fn(() => ({
@@ -189,6 +196,21 @@ describe('Signer', () => {
       metadata: mockMetadata,
       communicator: mockCommunicator,
       callback: mockCallback,
+    });
+
+    (getClient as Mock).mockImplementation((chainId) => {
+      if (chainId === 84532 || chainId === 1) {
+        return {
+          request: vi.fn(),
+          chain: {
+            id: chainId,
+          },
+          waitForTransaction: vi.fn().mockResolvedValue({
+            status: 'success',
+          }),
+        };
+      }
+      return null;
     });
   });
 
@@ -415,7 +437,6 @@ describe('Signer', () => {
       'wallet_sign',
       'personal_ecRecover',
       'eth_signTransaction',
-      'eth_sendTransaction',
       'eth_signTypedData_v1',
       'eth_signTypedData_v3',
       'eth_signTypedData_v4',
@@ -445,6 +466,105 @@ describe('Signer', () => {
           content: { encrypted: encryptedData },
         })
       );
+    });
+
+    it('should convert eth_sendTransaction to wallet_sendCalls and wait for transaction hash', async () => {
+      const txHash = `0x${'b'.repeat(64)}`;
+      const mockRequest: RequestArguments = {
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            to: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          },
+        ],
+      };
+
+      (decryptContent as Mock).mockResolvedValueOnce({
+        result: {
+          value: { id: '0x1234ca11' },
+        },
+      });
+      (waitForCallsStatus as Mock).mockResolvedValueOnce({
+        status: 'success',
+        receipts: [{ transactionHash: txHash }],
+      });
+
+      const result = await signer.request(mockRequest);
+
+      expect(encryptContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: expect.objectContaining({
+            method: 'wallet_sendCalls',
+            params: [
+              expect.objectContaining({
+                from: '0xAddress',
+                chainId: '0x1',
+                calls: [{ to: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', data: '0x', value: '0x0' }],
+              }),
+            ],
+          }),
+        }),
+        expect.anything()
+      );
+      expect(waitForCallsStatus).toHaveBeenCalledWith(expect.any(Object), { id: '0x1234ca11' });
+      expect(result).toEqual(txHash);
+    });
+
+    it('should handle legacy wallet_sendCalls string responses for eth_sendTransaction', async () => {
+      const txHash = `0x${'c'.repeat(64)}`;
+      const mockRequest: RequestArguments = {
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            to: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+            from: '0xAddress',
+          },
+        ],
+      };
+
+      (decryptContent as Mock).mockResolvedValueOnce({
+        result: {
+          value: '0xlegacycallsid',
+        },
+      });
+      (waitForCallsStatus as Mock).mockResolvedValueOnce({
+        status: 'success',
+        receipts: [{ transactionHash: txHash }],
+      });
+
+      const result = await signer.request(mockRequest);
+
+      expect(waitForCallsStatus).toHaveBeenCalledWith(expect.any(Object), { id: '0xlegacycallsid' });
+      expect(result).toEqual(txHash);
+    });
+
+    it('should support contract deployment transactions without to', async () => {
+      const txHash = `0x${'d'.repeat(64)}`;
+      const mockRequest: RequestArguments = {
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            data: '0x60006000',
+          },
+        ],
+      };
+
+      (decryptContent as Mock).mockResolvedValueOnce({
+        result: {
+          value: { id: '0xdeploycallsid' },
+        },
+      });
+      (waitForCallsStatus as Mock).mockResolvedValueOnce({
+        status: 'success',
+        receipts: [{ transactionHash: txHash }],
+      });
+
+      const result = await signer.request(mockRequest);
+      const sentAction = (encryptContent as Mock).mock.calls[0][0].action;
+
+      expect(sentAction.params[0].calls[0]).toEqual({ data: '0x60006000', value: '0x0' });
+      expect(waitForCallsStatus).toHaveBeenCalledWith(expect.any(Object), { id: '0xdeploycallsid' });
+      expect(result).toEqual(txHash);
     });
 
     it.each([

--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -1,5 +1,12 @@
 import { CB_WALLET_RPC_URL } from ':core/constants.js';
-import { Hex, WalletSendCallsParameters, hexToNumber, isAddressEqual, numberToHex } from 'viem';
+import {
+  Hex,
+  SendCallsReturnType,
+  WalletSendCallsParameters,
+  hexToNumber,
+  isAddressEqual,
+  numberToHex,
+} from 'viem';
 
 import { Communicator } from ':core/communicator/Communicator.js';
 import { isActionableHttpRequestError, isViemError, standardErrors } from ':core/error/errors.js';
@@ -55,12 +62,15 @@ import {
   assertFetchPermissionsRequest,
   assertGetCapabilitiesParams,
   assertParamsChainId,
+  createWalletSendCallsRequest,
   fillMissingParamsForFetchPermissions,
   getSenderFromRequest,
   initSubAccountConfig,
   injectRequestCapabilities,
+  isEthSendTransactionParams,
   makeDataSuffix,
   prependWithoutDuplicates,
+  waitForCallsTransactionHash,
 } from './utils.js';
 import { createSubAccountSigner } from './utils/createSubAccountSigner.js';
 import { findOwnerIndex } from './utils/findOwnerIndex.js';
@@ -249,8 +259,9 @@ export class Signer {
       case 'personal_sign':
       case 'wallet_sign':
       case 'personal_ecRecover':
-      case 'eth_signTransaction':
       case 'eth_sendTransaction':
+        return this.handleSendTransaction(request);
+      case 'eth_signTransaction':
       case 'eth_signTypedData_v1':
       case 'eth_signTypedData_v3':
       case 'eth_signTypedData_v4':
@@ -429,6 +440,45 @@ export class Signer {
         break;
     }
     return result.value;
+  }
+
+  /**
+   * Handles eth_sendTransaction by converting to wallet_sendCalls and
+   * waiting for the actual on-chain transaction hash.
+   *
+   * Without this, eth_sendTransaction sent via the popup returns the raw
+   * UserOperation signature (65 bytes) instead of a 32-byte tx hash,
+   * causing waitForTransactionReceipt to fail with InvalidParamsRpcError.
+   */
+  private async handleSendTransaction(request: RequestArguments) {
+    if (!isEthSendTransactionParams(request.params)) {
+      throw standardErrors.rpc.invalidParams('Invalid eth_sendTransaction params');
+    }
+
+    const txParams = request.params[0];
+    const from = txParams.from ?? this.accounts[0];
+
+    if (!from) {
+      throw standardErrors.rpc.invalidParams('No sender address available');
+    }
+
+    const sendCallsRequest = createWalletSendCallsRequest({
+      calls: [txParams],
+      chainId: this.chain.id,
+      from,
+    });
+
+    const result = (await this.sendRequestToPopup(sendCallsRequest)) as SendCallsReturnType;
+
+    const client = getClient(this.chain.id);
+    if (!client) {
+      throw standardErrors.rpc.internal(`No client found for chain ${this.chain.id}`);
+    }
+
+    return waitForCallsTransactionHash({
+      client,
+      id: result.id,
+    });
   }
 
   async cleanup() {

--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -41,7 +41,7 @@ import {
 } from ':core/telemetry/events/scw-sub-account.js';
 import { parseErrorMessageFromAny } from ':core/telemetry/utils.js';
 import { Address } from ':core/type/index.js';
-import { ensureIntNumber, hexStringFromNumber } from ':core/type/util.js';
+import { ensureHexString, ensureIntNumber, hexStringFromNumber } from ':core/type/util.js';
 import { SDKChain, createClients, getClient } from ':store/chain-clients/utils.js';
 import { correlationIds } from ':store/correlation-ids/store.js';
 import { spendPermissions, store } from ':store/store.js';
@@ -255,12 +255,12 @@ export class Signer {
         return this.handleGetCapabilitiesRequest(request);
       case 'wallet_switchEthereumChain':
         return this.handleSwitchChainRequest(request);
+      case 'eth_sendTransaction':
+        return this.handleSendTransaction(request);
       case 'eth_ecRecover':
       case 'personal_sign':
       case 'wallet_sign':
       case 'personal_ecRecover':
-      case 'eth_sendTransaction':
-        return this.handleSendTransaction(request);
       case 'eth_signTransaction':
       case 'eth_signTypedData_v1':
       case 'eth_signTypedData_v3':
@@ -462,13 +462,24 @@ export class Signer {
       throw standardErrors.rpc.invalidParams('No sender address available');
     }
 
+    const normalizedTxParams = {
+      ...(txParams.to ? { to: txParams.to } : {}),
+      data: ensureHexString(txParams.data ?? '0x', true) as Hex,
+      value: ensureHexString(txParams.value ?? '0x0', true) as Hex,
+    };
+
     const sendCallsRequest = createWalletSendCallsRequest({
-      calls: [txParams],
+      calls: [normalizedTxParams],
       chainId: this.chain.id,
       from,
     });
 
-    const result = (await this.sendRequestToPopup(sendCallsRequest)) as SendCallsReturnType;
+    const result = (await this.sendRequestToPopup(sendCallsRequest)) as SendCallsReturnType | string;
+    const callsId = typeof result === 'string' ? result : result.id;
+
+    if (!callsId) {
+      throw standardErrors.rpc.internal('wallet_sendCalls response is missing id');
+    }
 
     const client = getClient(this.chain.id);
     if (!client) {
@@ -477,7 +488,7 @@ export class Signer {
 
     return waitForCallsTransactionHash({
       client,
-      id: result.id,
+      id: callsId,
     });
   }
 

--- a/packages/account-sdk/src/sign/base-account/utils.test.ts
+++ b/packages/account-sdk/src/sign/base-account/utils.test.ts
@@ -14,6 +14,7 @@ import {
   getSenderFromRequest,
   initSubAccountConfig,
   injectRequestCapabilities,
+  isEthSendTransactionParams,
   isSendCallsParams,
   prependWithoutDuplicates,
   requestHasCapability,
@@ -625,6 +626,37 @@ describe('isSendCallsParams', () => {
   it('should return false for params with non-object first element', () => {
     expect(isSendCallsParams(['string'])).toBe(false);
     expect(isSendCallsParams([123])).toBe(false);
+  });
+});
+
+describe('isEthSendTransactionParams', () => {
+  it('should return true for contract deployments without to', () => {
+    expect(
+      isEthSendTransactionParams([
+        {
+          data: '0x60006000',
+        },
+      ])
+    ).toBe(true);
+  });
+
+  it('should return true for standard transaction params', () => {
+    expect(
+      isEthSendTransactionParams([
+        {
+          from: VALID_ADDRESS_1,
+          to: VALID_ADDRESS_2,
+          value: '0x1',
+          data: '0x',
+        },
+      ])
+    ).toBe(true);
+  });
+
+  it('should return false for invalid params', () => {
+    expect(isEthSendTransactionParams([])).toBe(false);
+    expect(isEthSendTransactionParams({})).toBe(false);
+    expect(isEthSendTransactionParams(null)).toBe(false);
   });
 });
 

--- a/packages/account-sdk/src/sign/base-account/utils.ts
+++ b/packages/account-sdk/src/sign/base-account/utils.ts
@@ -23,6 +23,17 @@ import { waitForCallsStatus } from 'viem/actions';
 import { getCryptoKeyAccount } from '../../kms/crypto-key/index.js';
 import { spendPermissionManagerAddress } from './utils/constants.js';
 
+type WalletSendCall = NonNullable<WalletSendCallsParameters[0]['calls']>[number];
+
+export type EthSendTransactionParams = [
+  {
+    from?: Address;
+    to?: Address;
+    data?: Hex;
+    value?: Hex;
+  },
+];
+
 // ***************************************************************
 // Utility
 // ***************************************************************
@@ -391,7 +402,7 @@ export function createWalletSendCallsRequest({
   chainId,
   capabilities,
 }: {
-  calls: { to: Address; data: Hex; value: Hex }[];
+  calls: WalletSendCall[];
   from: Address;
   chainId: number;
   capabilities?: Record<string, unknown>;
@@ -503,20 +514,12 @@ export function isSendCallsParams(params: unknown): params is WalletSendCallsPar
     'calls' in params[0]
   );
 }
-export function isEthSendTransactionParams(params: unknown): params is [
-  {
-    to: Address;
-    data: Hex;
-    from: Address;
-    value: Hex;
-  },
-] {
+export function isEthSendTransactionParams(params: unknown): params is EthSendTransactionParams {
   return (
     Array.isArray(params) &&
     params.length === 1 &&
     typeof params[0] === 'object' &&
-    params[0] !== null &&
-    'to' in params[0]
+    params[0] !== null
   );
 }
 export function compute16ByteHash(input: string): Hex {

--- a/packages/account-sdk/src/sign/base-account/utils/routeThroughGlobalAccount.ts
+++ b/packages/account-sdk/src/sign/base-account/utils/routeThroughGlobalAccount.ts
@@ -57,10 +57,26 @@ export async function routeThroughGlobalAccount({
     request.method === 'eth_sendTransaction' &&
     isEthSendTransactionParams(request.params)
   ) {
+    const from = request.params[0].from;
+    if (!from) {
+      throw new Error('Could not get sender from eth_sendTransaction request');
+    }
+
+    const to = request.params[0].to;
+    if (!to) {
+      throw new Error('Could not route contract deployment through global account');
+    }
+
     const sendCallsRequest = createWalletSendCallsRequest({
-      calls: [request.params[0]],
+      calls: [
+        {
+          to,
+          data: request.params[0].data ?? '0x',
+          value: request.params[0].value ?? '0x0',
+        },
+      ],
       chainId,
-      from: request.params[0].from,
+      from,
     });
 
     originalSendCallsParams = sendCallsRequest.params[0];
@@ -108,17 +124,20 @@ export async function routeThroughGlobalAccount({
     }
   );
 
-  const result = (await globalAccountRequest(requestToParent)) as SendCallsReturnType;
-
-  let callsId = result.id;
+  const result = (await globalAccountRequest(requestToParent)) as SendCallsReturnType | string;
+  const callsId = typeof result === 'string' ? result : result.id;
 
   // Cache returned spend permissions
-  if (result.capabilities?.spendPermissions) {
+  if (typeof result !== 'string' && result.capabilities?.spendPermissions) {
     spendPermissions.set(result.capabilities.spendPermissions.permissions);
   }
 
   // Wait for transaction hash if sending a transaction
   if (request.method === 'eth_sendTransaction') {
+    if (!callsId) {
+      throw new Error('wallet_sendCalls response is missing id');
+    }
+
     return waitForCallsTransactionHash({
       client,
       id: callsId,


### PR DESCRIPTION
## Summary

- Fix `eth_sendTransaction` for the global (universal) account path returning a raw 65-byte ECDSA signature instead of a 32-byte transaction hash
- Convert `eth_sendTransaction` to `wallet_sendCalls` and poll for the actual on-chain tx hash, matching the existing sub-account behavior

## Problem

When `eth_sendTransaction` is called for a global account, the request is sent directly to the wallet popup via `sendRequestToPopup()`. The popup returns a raw 65-byte ECDSA signature (`r + s + v`) instead of a transaction hash. This value is returned as-is by `handleResponse()` (falls through to default case), causing downstream `waitForTransactionReceipt()` to fail:

```
InvalidParamsRpcError: invalid argument 0: hex string has length 130, want 64 for common.Hash
```

## Root Cause

Three paths exist for `eth_sendTransaction`:

| Path | Flow | Result |
|------|------|--------|
| Sub-account (with permissions) | `eth_sendTransaction` → `wallet_sendCalls` → `waitForCallsTransactionHash()` | ✅ 32-byte tx hash |
| Sub-account (without permissions) | `eth_sendTransaction` → `wallet_sendCalls` via global account → `waitForCallsTransactionHash()` | ✅ 32-byte tx hash |
| **Global account (this bug)** | `eth_sendTransaction` → popup → `handleResponse()` default → `return result.value` | ❌ 65-byte signature |

## Fix

Apply the same pattern already used by `createSubAccountSigner.ts` (L86-117) and `routeThroughGlobalAccount.ts` (L56-126):

1. Convert `eth_sendTransaction` params to `wallet_sendCalls`
2. Send `wallet_sendCalls` to popup → returns a `callsId`
3. `waitForCallsTransactionHash(callsId)` polls `wallet_getCallsStatus` → returns the actual 32-byte tx hash

## Test plan

- [ ] Verify `eth_sendTransaction` with global account returns a 32-byte tx hash
- [ ] Verify sub-account paths are unaffected
- [ ] Verify signing methods (`personal_sign`, `eth_signTypedData_v4`, etc.) still go through popup unchanged

Fixes #251

## Context
- Tracking issue: #251 