### PR TITLE
fix: propagate pay dataSuffix to sendCalls attribution

### DIFF
--- a/packages/account-sdk/src/interface/payment/pay.test.ts
+++ b/packages/account-sdk/src/interface/payment/pay.test.ts
@@ -74,6 +74,7 @@ describe('pay', () => {
       '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51',
       '10.50',
       false,
+      undefined,
       undefined
     );
 
@@ -134,6 +135,7 @@ describe('pay', () => {
       '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51', // checksummed address passed to translate
       '10.50',
       false,
+      undefined,
       undefined
     );
   });
@@ -202,6 +204,18 @@ describe('pay', () => {
       correlationId: 'mock-correlation-id',
       errorMessage: 'Invalid amount: must be greater than 0',
     });
+  });
+
+  it('should reject invalid dataSuffix format', async () => {
+    vi.mocked(validation.validateStringAmount).mockReturnValue(undefined);
+
+    await expect(
+      pay({
+        amount: '10.50',
+        to: '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51',
+        dataSuffix: 'not-hex' as any,
+      })
+    ).rejects.toThrow('Invalid dataSuffix: expected a 0x-prefixed hex string');
   });
 
   it('should handle SDK execution errors', async () => {
@@ -377,6 +391,7 @@ describe('pay', () => {
       '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51',
       '5.00',
       true,
+      undefined,
       undefined
     );
     expect(sdkManager.executePaymentWithSDK).toHaveBeenCalledWith(
@@ -460,7 +475,8 @@ describe('pay', () => {
       '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51',
       '10.50',
       false,
-      payerInfo
+      payerInfo,
+      undefined
     );
   });
 
@@ -481,6 +497,14 @@ describe('pay', () => {
       to: '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51',
       dataSuffix: '0xabc123',
     });
+
+    expect(translatePayment.translatePaymentToSendCalls).toHaveBeenCalledWith(
+      '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51',
+      '10.50',
+      false,
+      undefined,
+      '0xabc123'
+    );
 
     expect(sdkManager.executePaymentWithSDK).toHaveBeenCalledWith(
       expect.any(Object),

--- a/packages/account-sdk/src/interface/payment/pay.ts
+++ b/packages/account-sdk/src/interface/payment/pay.ts
@@ -6,7 +6,7 @@ import {
 import type { PaymentOptions, PaymentResult } from './types.js';
 import { executePaymentWithSDK } from './utils/sdkManager.js';
 import { translatePaymentToSendCalls } from './utils/translatePayment.js';
-import { normalizeAddress, validateStringAmount } from './utils/validation.js';
+import { normalizeAddress, validateDataSuffix, validateStringAmount } from './utils/validation.js';
 
 /**
  * Pay a specified address with USDC on Base network using an ephemeral wallet
@@ -57,13 +57,17 @@ export async function pay(options: PaymentOptions): Promise<PaymentResult> {
   try {
     validateStringAmount(amount, 6);
     const normalizedAddress = normalizeAddress(to);
+    if (dataSuffix !== undefined) {
+      validateDataSuffix(dataSuffix);
+    }
 
     // Step 2: Translate payment to sendCalls format
     const requestParams = translatePaymentToSendCalls(
       normalizedAddress,
       amount,
       testnet,
-      payerInfo
+      payerInfo,
+      dataSuffix
     );
 
     // Step 3: Execute payment with SDK

--- a/packages/account-sdk/src/interface/payment/utils/translatePayment.test.ts
+++ b/packages/account-sdk/src/interface/payment/utils/translatePayment.test.ts
@@ -41,6 +41,31 @@ describe('translatePayment', () => {
       });
     });
 
+    it('should include attribution suffix when dataSuffix is provided', () => {
+      const transferData = '0xabcdef';
+      const testnet = false;
+      const dataSuffix = '0xfeedbeef';
+
+      const result = buildSendCallsRequest(transferData, testnet, undefined, dataSuffix);
+
+      expect(result).toEqual({
+        version: '2.0.0',
+        chainId: CHAIN_IDS.base,
+        calls: [
+          {
+            to: TOKENS.USDC.addresses.base,
+            data: transferData,
+            value: '0x0',
+          },
+        ],
+        capabilities: {
+          attribution: {
+            suffix: dataSuffix,
+          },
+        },
+      });
+    });
+
     it('should build request with payerInfo', () => {
       const transferData = '0xabcdef';
       const testnet = false;
@@ -251,6 +276,32 @@ describe('translatePayment', () => {
           dataCallback: {
             requests: [{ type: 'name', optional: true }],
             callbackURL: 'https://example.com/callback',
+          },
+        },
+      });
+    });
+
+    it('should translate payment with dataSuffix attribution capability', () => {
+      const recipient = '0xFe21034794A5a574B94fE4fDfD16e005F1C96e51';
+      const amount = '10.50';
+      const testnet = false;
+      const dataSuffix = '0xfeedbeef';
+
+      const result = translatePaymentToSendCalls(recipient, amount, testnet, undefined, dataSuffix);
+
+      expect(result).toEqual({
+        version: '2.0.0',
+        chainId: CHAIN_IDS.base,
+        calls: [
+          {
+            to: TOKENS.USDC.addresses.base,
+            data: expect.stringMatching(/^0x[a-fA-F0-9]+$/),
+            value: '0x0',
+          },
+        ],
+        capabilities: {
+          attribution: {
+            suffix: dataSuffix,
           },
         },
       });

--- a/packages/account-sdk/src/interface/payment/utils/translatePayment.ts
+++ b/packages/account-sdk/src/interface/payment/utils/translatePayment.ts
@@ -24,9 +24,15 @@ export function encodeTransferCall(recipient: Address, amount: string): Hex {
  * @param transferData - The encoded transfer call data
  * @param testnet - Whether to use testnet
  * @param payerInfo - Optional payer information configuration for data callbacks
+ * @param dataSuffix - Optional 0x-prefixed hex attribution suffix
  * @returns The request parameters for wallet_sendCalls
  */
-export function buildSendCallsRequest(transferData: Hex, testnet: boolean, payerInfo?: PayerInfo) {
+export function buildSendCallsRequest(
+  transferData: Hex,
+  testnet: boolean,
+  payerInfo?: PayerInfo,
+  dataSuffix?: Hex
+) {
   const network = testnet ? 'baseSepolia' : 'base';
   const chainId = CHAIN_IDS[network];
   const usdcAddress = TOKENS.USDC.addresses[network];
@@ -52,6 +58,10 @@ export function buildSendCallsRequest(transferData: Hex, testnet: boolean, payer
     };
   }
 
+  if (dataSuffix) {
+    capabilities.attribution = { suffix: dataSuffix };
+  }
+
   // Build the request parameters
   const requestParams = {
     version: '2.0.0',
@@ -69,17 +79,19 @@ export function buildSendCallsRequest(transferData: Hex, testnet: boolean, payer
  * @param amount - The amount to send
  * @param testnet - Whether to use testnet
  * @param payerInfo - Optional payer information configuration for data callbacks
+ * @param dataSuffix - Optional 0x-prefixed hex attribution suffix
  * @returns The complete request parameters
  */
 export function translatePaymentToSendCalls(
   recipient: Address,
   amount: string,
   testnet: boolean,
-  payerInfo?: PayerInfo
+  payerInfo?: PayerInfo,
+  dataSuffix?: Hex
 ) {
   // Encode the transfer call
   const transferData = encodeTransferCall(recipient, amount);
 
   // Build and return the sendCalls request
-  return buildSendCallsRequest(transferData, testnet, payerInfo);
+  return buildSendCallsRequest(transferData, testnet, payerInfo, dataSuffix);
 }

--- a/packages/account-sdk/src/interface/payment/utils/validation.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.ts
@@ -1,4 +1,4 @@
-import { type Address, getAddress } from 'viem';
+import { type Address, type Hex, getAddress, isHex } from 'viem';
 
 /**
  * Validates that the amount is a positive string with max decimal places
@@ -49,4 +49,16 @@ export function normalizeAddress(address: string): Address {
   } catch (_error) {
     throw new Error('Invalid address: must be a valid Ethereum address');
   }
+}
+
+/**
+ * Validates data suffix format.
+ * @param dataSuffix - 0x-prefixed hex data suffix
+ * @throws Error if data suffix is invalid
+ */
+export function validateDataSuffix(dataSuffix: string): Hex {
+  if (!isHex(dataSuffix)) {
+    throw new Error('Invalid dataSuffix: expected a 0x-prefixed hex string');
+  }
+  return dataSuffix;
 }


### PR DESCRIPTION
## Summary
- pass `dataSuffix` through `pay()` into `translatePaymentToSendCalls(...)` so wallet payloads include `capabilities.attribution.suffix`
- validate `dataSuffix` format in payment validation path before request translation
- add/update payment translation and pay tests to cover attribution suffix propagation and invalid suffix handling

## Test plan
- [x] `node packages/account-sdk/compile-assets.cjs`
- [x] `yarn workspace @base-org/account typecheck`
- [x] `yarn workspace @base-org/account test --run`
- [x] `yarn lint`
- [x] `yarn workspace @base-org/account test --run src/interface/payment/pay.test.ts src/interface/payment/utils/translatePayment.test.ts`

Made with [Cursor](https://cursor.com)