### PR TITLE
chore: bump @base-org/account to 2.5.3

### DIFF
--- a/packages/account-sdk/package.json
+++ b/packages/account-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@base-org/account",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Base Account SDK",
   "keywords": [
     "base",


### PR DESCRIPTION
Release version bump for `@base-org/account` from 2.5.2 to 2.5.3.

Made with [Cursor](https://cursor.com)