### PR TITLE
fix: testapp eth_signTypedData_v4 Example Message verify crash

### DIFF
--- a/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
+++ b/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
@@ -124,7 +124,7 @@ export function RpcMethodCard({ format, method, params, shortcuts }) {
         method,
         from: typeof data.address === 'string' ? data.address.toLowerCase() : undefined,
         sign: response,
-        message: typeof data.message === 'string' ? data.message : undefined,
+        message: data.message,
         chain: chain as Chain,
       });
 


### PR DESCRIPTION
## Summary

Fixes the "Example Message" shortcut button for `eth_signTypedData_v4` in the testapp playground, which was crashing with:

```json
{ "message": "Cannot read properties of undefined (reading 'domain')" }
```

## Cause

Introduced in #217 (commit `69fbee3b` — "Fix SDK source reload and remove noExplicitAny suppressions"), a type-narrowing guard was added to the `verify` flow in `RpcMethodCard.tsx`:

```ts
// Before #217
message: data.message,

// After #217
message: typeof data.message === 'string' ? data.message : undefined,
```

This guard was intended to satisfy Biome's `noExplicitAny` rule, but it's overly restrictive. When shortcuts call `submit(shortcut.data)` directly (bypassing the form), `data.message` is a **JavaScript object** — not a JSON string — because the shortcut data stores typed data payloads as objects (required for `replaceAddressInValue` to do deep placeholder replacement like `YOUR_ADDRESS_HERE`). The guard drops the object and passes `undefined` to `verifySignMsg`, which then crashes on `typedData['domain']`.

The form-based path is unaffected because textarea values are always strings.

## Fix

Pass `data.message` through as-is. `verifySignMsg` already handles both strings and objects correctly:

```ts
const typedData = typeof message === 'string' ? JSON.parse(message) : message;
```

This also affects `eth_signTypedData_v3` shortcuts which have the same object-based message structure.

## Test plan

- [x] Open testapp playground
- [x] Connect a wallet
- [x] Under `eth_signTypedData_v4`, click the "Example Message" shortcut button
- [x] Verify signature is submitted and verified without error
- [ ] Also test "Grant Permission" shortcut under `eth_signTypedData_v4`
- [ ] Also test "Example Message" shortcut under `eth_signTypedData_v3`


Made with [Cursor](https://cursor.com)