### PR TITLE
fix(docs): add missing await on provider.request() calls in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ yarn add @base-org/account
 3. Request accounts to initialize a connection to wallet
 
    ```js
-   const addresses = provider.request({
+   const addresses = await provider.request({
      method: 'eth_requestAccounts',
    });
    ```
@@ -181,7 +181,7 @@ yarn add @base-org/account
 4. Make more requests
 
    ```js
-   provider.request('personal_sign', [
+   await provider.request('personal_sign', [
      `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
      addresses[0],
    ]);


### PR DESCRIPTION
Was going through the README and noticed two code examples are missing await on provider.request() calls. Since provider.request() returns a Promise, without await the const addresses variable ends up being a Promise object instead of an array of addresses. Anyone following these examples will run into unexpected behavior. Lines 176 and 184 in README.md.