### PR TITLE
chore: bump @base-org/account to 2.5.4

### DIFF
--- a/packages/account-sdk/package.json
+++ b/packages/account-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@base-org/account",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Base Account SDK",
   "keywords": [
     "base",


### PR DESCRIPTION
## Summary
- Bumps `@base-org/account` package version from 2.5.3 to 2.5.4

## Test plan
- [ ] Verify package.json version is correct
- [ ] CI passes

Made with [Cursor](https://cursor.com)