### PR TITLE
chore: sync release-please manifest with account-sdk 2.5.4

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/account-sdk": "2.5.3",
+  "packages/account-sdk": "2.5.4",
   "packages/account-ui": "1.0.1"
 }


### PR DESCRIPTION
## Summary
- Updates `.release-please-manifest.json` to point account-sdk at `2.5.4` (matching the actual `package.json` version and GitHub release)
- The manifest was stuck at `2.5.3`, causing release-please to scan from the wrong base commit and skip account-sdk when generating release PRs

## Test plan
- [ ] Verify CI passes
- [ ] After merge, confirm release-please creates a release PR for account-sdk

Made with [Cursor](https://cursor.com)