### PR TITLE
ci: resolve latest Opus model dynamically for Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -41,6 +41,40 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
+
+      - name: Resolve latest Opus model from LLM Gateway
+        id: resolve-model
+        env:
+          LLM_GATEWAY_API_KEY: ${{ secrets.LLM_GATEWAY_API_KEY }}
+          LLM_GATEWAY_HOSTNAME: ${{ vars.LLM_GATEWAY_HOSTNAME }}
+        run: |
+          set -euo pipefail
+
+          # Hardcoded fallback used if the gateway lookup fails or returns no matches.
+          # Bump this manually when a newer Opus family is known to be available.
+          FALLBACK="claude-opus-4-6"
+          resolved=""
+
+          if response=$(curl -sS --max-time 15 --fail \
+            -H "Authorization: Bearer ${LLM_GATEWAY_API_KEY}" \
+            "https://${LLM_GATEWAY_HOSTNAME}/v1/models"); then
+            # Match only clean Opus version aliases (e.g. claude-opus-4-6),
+            # excluding suffixed variants like -default, [1m], #priority.
+            resolved=$(printf '%s' "$response" \
+              | jq -r '.data[].id? // empty | select(test("^claude-opus-[0-9]+(-[0-9]+)?$"))' 2>/dev/null \
+              | sort -V \
+              | tail -1) || resolved=""
+          fi
+
+          if [ -z "${resolved}" ]; then
+            resolved="${FALLBACK}"
+            echo "::warning::Could not resolve latest Opus from gateway; using fallback ${FALLBACK}"
+          else
+            echo "::notice::Resolved latest Opus model: ${resolved}"
+          fi
+
+          echo "model=${resolved}" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code
         id: claude-review
         uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
@@ -154,5 +188,5 @@ jobs:
             Note: --delete-last only deletes your own top-level comments, not inline review comments or other users' comments.
 
           claude_args: |
-            --model claude-opus-4-6-default
+            --model ${{ steps.resolve-model.outputs.model }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr edit ${{ github.event.pull_request.number }} --title:*),Bash(gh pr comment ${{ github.event.pull_request.number }} --body:*),Bash(gh pr comment ${{ github.event.pull_request.number }} --edit-last --body:*),Bash(gh pr comment ${{ github.event.pull_request.number }} --delete-last:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments:*)"


### PR DESCRIPTION
## Summary

- Replace the hardcoded `--model claude-opus-4-6-default` in the Claude Code review workflow with a dynamically resolved model
- New pre-step queries the LLM Gateway's `/v1/models` endpoint, filters for clean Opus aliases matching `claude-opus-N(-M)?` (excludes `-default`, `[1m]`, `#priority`, and non-Opus families), sorts with `sort -V`, and picks the highest
- Falls back to `claude-opus-4-6` if the gateway is unreachable, returns a non-2xx, returns malformed JSON, or yields no matches — so the workflow stays functional under all failure modes

## Why

The reviewer was pinned to a single Opus string, so picking up newer families (e.g., `claude-opus-4-7`, `claude-opus-5`) required a workflow edit. This makes the version tracking automatic while still letting us manually bump the safety-net fallback.

Relevant context:
- [LLM Gateway model aliases doc](https://docs.cbhq.net/app-services/genai-platform/llm-gateway/models/available-models) — within-family updates are automatic; cross-family is manual
- [GENAI-1809](https://linear.app/coinbase/issue/GENAI-1809) — Anthropic retirement cadence means pinning can silently go stale
- The gateway hostname is already in the `harden-runner` egress allowlist, so no network policy changes needed

## Behavior

| Scenario | Result |
| --- | --- |
| Gateway returns list with `claude-opus-4-6`, `...-default`, Sonnet, GPT | Picks `claude-opus-4-6` (filters out `-default` and non-Opus) |
| Gateway returns future `claude-opus-5-1` | Picks `claude-opus-5-1` automatically |
| Gateway times out / 5xx / auth fails | Falls back to `claude-opus-4-6`, emits `::warning::` |
| Gateway returns empty `data: []` | Falls back to `claude-opus-4-6`, emits `::warning::` |

Verified the `jq` filter + `sort -V` pipeline locally against mock gateway responses (including multi-family, suffixed aliases, and empty cases).

## Test plan

- [ ] CI lint/typecheck passes on this branch
- [ ] After merge, next PR's Claude review job logs a `::notice::Resolved latest Opus model: claude-opus-<version>` line
- [ ] Review comment posts successfully using the resolved model (same behavior as today, just sourced dynamically)


Made with [Cursor](https://cursor.com)