### PR TITLE
docs: add missing await to README provider.request() examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ yarn add @base-org/account
 3. Request accounts to initialize a connection to wallet
 
    ```js
-   const addresses = provider.request({
+   const addresses = await provider.request({
      method: 'eth_requestAccounts',
    });
    ```
@@ -181,7 +181,7 @@ yarn add @base-org/account
 4. Make more requests
 
    ```js
-   provider.request('personal_sign', [
+   await provider.request('personal_sign', [
      `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
      addresses[0],
    ]);

--- a/packages/account-sdk/README.md
+++ b/packages/account-sdk/README.md
@@ -78,7 +78,7 @@
 3. Request accounts to initialize a connection to wallet
 
    ```js
-   const addresses = provider.request({
+   const addresses = await provider.request({
      method: 'eth_requestAccounts',
    });
    ```
@@ -86,7 +86,7 @@
 4. Make more requests
 
    ```js
-   provider.request('personal_sign', [
+   await provider.request('personal_sign', [
      `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
      addresses[0],
    ]);


### PR DESCRIPTION
## Problem

Two quickstart code blocks in `README.md` (lines 176, 184) and the duplicated block in `packages/account-sdk/README.md` (lines 81, 89) call `provider.request()` without `await`. Per `packages/account-sdk/src/core/provider/interface.ts` the Provider signature is `request(args: RequestArguments): Promise<unknown>`, so the examples as written assign a Promise to `addresses` and the following step indexes it as `addresses[0]` — which is `undefined`. The `personal_sign` call in step 4 is also fire-and-forget.

## Fix

Added `await` to both `provider.request()` invocations in both READMEs so the quickstart actually works when copied.

## Changes

- **`README.md`** — Prefixed `await` on the `eth_requestAccounts` call (line 176) and on the `personal_sign` call (line 184) in the Basic SDK Usage section
- **`packages/account-sdk/README.md`** — Same fix applied to the mirrored quickstart (lines 81, 89)

## Testing

- Verified `request` is typed as `request(args: RequestArguments): Promise<unknown>;` in `packages/account-sdk/src/core/provider/interface.ts`
- Confirmed without `await`, `addresses[0]` in the `personal_sign` step is `undefined`
- Checked no other README code blocks use `provider.request` without awaiting

Closes #272