### PR TITLE
ci: read Claude review model from repo variable

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -154,5 +154,5 @@ jobs:
             Note: --delete-last only deletes your own top-level comments, not inline review comments or other users' comments.
 
           claude_args: |
-            --model claude-opus-4-6-default
+            --model ${{ vars.CLAUDE_MODEL }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr edit ${{ github.event.pull_request.number }} --title:*),Bash(gh pr comment ${{ github.event.pull_request.number }} --body:*),Bash(gh pr comment ${{ github.event.pull_request.number }} --edit-last --body:*),Bash(gh pr comment ${{ github.event.pull_request.number }} --delete-last:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments:*)"


### PR DESCRIPTION
## Summary
- Swap the hardcoded `--model claude-opus-4-6-default` in `.github/workflows/claude-review.yml` for `${{ vars.CLAUDE_MODEL }}` so the model used by the Claude Code Review workflow can be managed via a repo Actions variable.
- Matches the existing pattern already used for `LLM_GATEWAY_HOSTNAME` in the same workflow.

## Test plan
- [x] Set `CLAUDE_MODEL` repo variable.
- [ ] Open/sync a PR and confirm the `Claude Code Review` job passes and uses the configured model.


Made with [Cursor](https://cursor.com)