### PR TITLE
fix: use nextOwnerIndex instead of ownerCount in findOwnerIndex

### DIFF
--- a/packages/account-sdk/src/sign/base-account/utils/findOwnerIndex.test.ts
+++ b/packages/account-sdk/src/sign/base-account/utils/findOwnerIndex.test.ts
@@ -17,7 +17,7 @@ describe('findOwnerIndex', () => {
   it('returns correct index when owner found', async () => {
     const mockReadContract = vi
       .fn()
-      .mockResolvedValueOnce(BigInt(3)) // ownerCount
+      .mockResolvedValueOnce(BigInt(3)) // nextOwnerIndex
       .mockResolvedValueOnce('0x00000000000000000000000046440ECd6746f7612809eFED388347d476369f6D') // owner at index 2
       .mockResolvedValueOnce('0x000000000000000000000000d9Ec1a8603125732c1ee35147619BbFA769A062b') // owner at index 1
       .mockResolvedValueOnce('0x0000000000000000000000007838d2724FC686813CAf81d4429beff1110c739a'); // owner at index 0
@@ -37,7 +37,7 @@ describe('findOwnerIndex', () => {
   it('only calls readContract as needed', async () => {
     const mockReadContract = vi
       .fn()
-      .mockResolvedValueOnce(BigInt(3)) // ownerCount
+      .mockResolvedValueOnce(BigInt(3)) // nextOwnerIndex
       .mockResolvedValueOnce('0x00000000000000000000000046440ECd6746f7612809eFED388347d476369f6D') // owner at index 2
       .mockResolvedValueOnce('0x000000000000000000000000d9Ec1a8603125732c1ee35147619BbFA769A062b') // owner at index 1
       .mockResolvedValueOnce('0x0000000000000000000000007838d2724FC686813CAf81d4429beff1110c739a'); // owner at index 0
@@ -57,7 +57,7 @@ describe('findOwnerIndex', () => {
   it('handles 64 byte public keys', async () => {
     const mockReadContract = vi
       .fn()
-      .mockResolvedValueOnce(BigInt(2)) // ownerCount
+      .mockResolvedValueOnce(BigInt(2)) // nextOwnerIndex
       .mockResolvedValueOnce(
         '0xe7575170745fe55d7a26190c6d5504743496c49498b129d2b3660da3697e81d4daebb2496f89aa4a05f1705e1d5d316153211c198f80d3100b51489bf4963f47'
       ) // owner at index 1
@@ -79,7 +79,7 @@ describe('findOwnerIndex', () => {
   it('is case insensitive when matching owners', async () => {
     const mockReadContract = vi
       .fn()
-      .mockResolvedValueOnce(BigInt(2)) // ownerCount
+      .mockResolvedValueOnce(BigInt(2)) // nextOwnerIndex
       .mockResolvedValueOnce('0xAAA') // owner at index 1
       .mockResolvedValueOnce('0xBBB'); // owner at index 0
 
@@ -97,7 +97,7 @@ describe('findOwnerIndex', () => {
   it('throws error when owner not found', async () => {
     const mockReadContract = vi
       .fn()
-      .mockResolvedValueOnce(BigInt(2)) // ownerCount
+      .mockResolvedValueOnce(BigInt(2)) // nextOwnerIndex
       .mockResolvedValueOnce('0xaaa') // owner at index 1
       .mockResolvedValueOnce('0xbbb'); // owner at index 0
 
@@ -112,7 +112,7 @@ describe('findOwnerIndex', () => {
   });
 
   it('handles empty owner list', async () => {
-    const mockReadContract = vi.fn().mockResolvedValueOnce(BigInt(0)); // ownerCount
+    const mockReadContract = vi.fn().mockResolvedValueOnce(BigInt(0)); // nextOwnerIndex
 
     (readContract as Mock).mockImplementation(mockReadContract);
 
@@ -122,6 +122,28 @@ describe('findOwnerIndex', () => {
       publicKey: '0xccc',
     });
     expect(result).toBe(-1);
+  });
+
+  it('finds owner at high index when previous owners have been removed', async () => {
+    // Simulates: nextOwnerIndex=3, but owner at index 1 was removed (returns 0x)
+    // Owner at index 2 should still be found
+    const mockReadContract = vi
+      .fn()
+      .mockResolvedValueOnce(BigInt(3)) // nextOwnerIndex
+      .mockResolvedValueOnce('0xCCC') // owner at index 2 (the one we're looking for)
+      .mockResolvedValueOnce('0x') // owner at index 1 (removed, empty bytes)
+      .mockResolvedValueOnce('0xAAA'); // owner at index 0
+
+    (readContract as Mock).mockImplementation(mockReadContract);
+
+    const result = await findOwnerIndex({
+      address: '0xabc',
+      client,
+      publicKey: '0xCCC',
+    });
+
+    expect(result).toBe(2);
+    expect(mockReadContract).toHaveBeenCalledTimes(2); // nextOwnerIndex + ownerAtIndex(2)
   });
 
   it('finds owner index from factory data when contract not deployed', async () => {

--- a/packages/account-sdk/src/sign/base-account/utils/findOwnerIndex.ts
+++ b/packages/account-sdk/src/sign/base-account/utils/findOwnerIndex.ts
@@ -56,14 +56,19 @@ export async function findOwnerIndex({
     });
   }
 
-  const ownerCount = await readContract(client, {
+  const nextOwnerIndex = await readContract(client, {
     address,
     abi,
-    functionName: 'ownerCount',
+    functionName: 'nextOwnerIndex',
   });
 
-  // Iterate from highest index down and return early when found
-  for (let i = Number(ownerCount) - 1; i >= 0; i--) {
+  // Iterate from highest index down and return early when found.
+  // We use nextOwnerIndex instead of ownerCount because ownerCount
+  // excludes removed owners (ownerCount = nextOwnerIndex - removedOwnersCount),
+  // which causes us to miss owners at higher indices when previous owners
+  // have been removed. Removed owner slots return empty bytes (0x) and are
+  // skipped naturally by the comparison below.
+  for (let i = Number(nextOwnerIndex) - 1; i >= 0; i--) {
     const owner = await readContract(client, {
       address,
       abi,


### PR DESCRIPTION
### _Summary_

`findOwnerIndex` used `ownerCount()` to bound its iteration over owner slots. However, `ownerCount = nextOwnerIndex - removedOwnersCount`, which means it skips owners at higher indices when previous owners have been removed.

For example, a sub-account with `nextOwnerIndex=15` and `removedOwnersCount=13` reports `ownerCount=2`, so `findOwnerIndex` only checks indices 0-1 — missing the owner at index 14. This causes a false negative, triggering an unnecessary reauthorization flow that attempts `addOwnerPublicKey` and reverts onchain with `AlreadyOwner`.

The fix changes the iteration bound from `ownerCount()` to `nextOwnerIndex()`, ensuring all owner slots (including those at high indices after removals) are checked. Empty slots from removed owners return `0x` and are naturally skipped by the comparison.

### _How did you test your changes?_

- Existing unit tests updated (comments changed from `ownerCount` to `nextOwnerIndex`)
- Added new test case: `finds owner at high index when previous owners have been removed`
- All 11 tests pass
- Verified against a real production sub-account (`0x463f3D229E2fe046807d189CCD0cE9758851f10b`) on Base where this exact bug was occurring