### PR TITLE
ci: reduce release-please commit batch size

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "commit-batch-size": 1,
   "packages": {
     "packages/account-sdk": {
       "package-name": "@base-org/account",


### PR DESCRIPTION
## Summary
- Configure release-please to fetch commit history one commit per GitHub GraphQL request.
- Work around repeated GitHub GraphQL internal errors while release-please is collecting merge commits on `master`.

## Why
The release-please workflow is failing before any package build or npm publish step. The logs show release-please successfully loading config, finding the latest releases for both packages, and then failing while paging merge commits through GitHub GraphQL:

```text
✔ Collecting commits since all latest releases
❯ Fetching merge commits on branch master with cursor: ...
Error: release-please failed: Request failed due to following response errors:
 - Something went wrong while executing your query ...
```

That `Something went wrong while executing your query` / `E001` response is a GitHub GraphQL internal error. In this case, it is happening while release-please is fetching commit history, so reducing the per-request commit batch size makes each GraphQL query smaller and less likely to timeout or hit a GitHub-side execution failure.

## Source For The Fix
Release-please v17.3.0 added `commit-batch-size` specifically to make commit-history pagination configurable:

- Release notes: https://github.com/googleapis/release-please/releases/tag/v17.3.0
- Upstream PR: https://github.com/googleapis/release-please/pull/2679

The upstream PR describes the same failure mode: release-please consistently hitting GitHub GraphQL 502/internal errors while querying repository history, and succeeding only after lowering the number of commits fetched per request.

## Tradeoff
Setting `commit-batch-size` to `1` increases the number of GitHub API calls, so the release-please job may run slower. The benefit is that each GraphQL request is much smaller, which should make the workflow more reliable for the current failure.

## Test plan
- Validated `release-please-config.json` parses as JSON.
- Existing CI will run on the PR.