### PR TITLE
ci: grant release-please issues permission

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `issues: write` to the Release Please workflow token permissions.
- Keep the previously merged `commit-batch-size: 1` mitigation in place.

## Why
The release-please workflow is still failing inside GitHub Actions while executing the first commit-history GraphQL query, even after reducing the commit batch size to 1.

I reproduced the reduced release-please GraphQL query locally with `gh api graphql`, and it succeeds against `master`. The remaining difference is the token used in Actions: the workflow uses `secrets.GITHUB_TOKEN` with only `contents: write` and `pull-requests: write`.

Release Please's documented required workflow permissions include `issues: write` as well:

https://github.com/googleapis/release-please-action?tab=readme-ov-file#workflow-permissions

That permission is relevant because release-please reads PR labels in the failing GraphQL query and may create/update labels on release PRs.

## Test plan
- Verified the workflow YAML diff is limited to adding `issues: write`.
- Existing CI will run on the PR.
- After merge, rerun the Release Please workflow on `master`.

Made with [Cursor](https://cursor.com)