### PR TITLE
revert: undo release-please commit batch size change (#283)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "commit-batch-size": 1,
   "packages": {
     "packages/account-sdk": {
       "package-name": "@base-org/account",


### PR DESCRIPTION
## Summary
- Reverts #283, which set `commit-batch-size: 1` in `release-please-config.json`.

## Why
Reverting the change to the release-please commit batch size.

## Test plan
- [ ] Existing CI runs on the PR.

Made with [Cursor](https://cursor.com)