### PR TITLE
ci: use PAT for release-please so release PRs trigger CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,11 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT (or GitHub App token) instead of GITHUB_TOKEN so that
+          # release-please's release PRs trigger CI. Events from GITHUB_TOKEN
+          # do not start new workflow runs:
+          # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   publish-account:
     needs: release-please


### PR DESCRIPTION
## Summary

Release PRs opened by `release-please-action` are authored by the default `GITHUB_TOKEN`, and [per GitHub's docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) events triggered by `GITHUB_TOKEN` **do not start new workflow runs**:

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run.

That's why the current open release PR (#286) shows only Heimdall + StepSecurity checks — none of `Lint Check`, `Format Check`, `Type Check`, `Tests`, or `PR Title` ever ran.

This PR switches `release-please-action` to read its token from a `RELEASE_PLEASE_TOKEN` secret instead. With a PAT (or GitHub App installation token) backing it, the resulting `pull_request` events fire normally and CI runs on every release PR.

## Required setup before merging

1. Create a token with `contents: read/write`, `pull-requests: read/write`, and `issues: read/write` on `base/account-sdk`. Either:
   - **Classic PAT** with the `repo` scope, or
   - **Fine-grained PAT** scoped to this repo, or
   - **GitHub App** installation token via `actions/create-github-app-token`.
2. If `base` enforces SAML SSO, authorize the token for the `base` org.
3. Add it as a repo secret named `RELEASE_PLEASE_TOKEN` at https://github.com/base/account-sdk/settings/secrets/actions.

## Post-merge

The next push to `master` will (re)open the release PR under the new token's identity, and CI will run on it. The currently-open #286 was created under the old `GITHUB_TOKEN` identity; closing and reopening it (or letting release-please recreate it after this lands) will make CI run there too.

## Test plan

- [ ] `RELEASE_PLEASE_TOKEN` secret is configured on the repo
- [ ] After merging, confirm the next release PR (or a re-opened #286) shows `Lint Check`, `Format Check`, `Type Check`, `Tests` (Node 20/22/24), and `PR Title` checks
- [ ] Confirm the release PR is authored by the token's owner (not `github-actions[bot]`)

Made with [Cursor](https://cursor.com)