### PR TITLE
ci: rename release-account-manual.yml to release-account.yml

### DIFF
--- a/.github/workflows/release-account.yml
+++ b/.github/workflows/release-account.yml
@@ -1,7 +1,14 @@
-# DEPRECATED: This workflow is superseded by the release-please automation (release-please.yml).
-# Use this only as a fallback if release-please fails.
-# To be removed after the first successful automated release.
-name: "[DEPRECATED] Release Account (Manual)"
+# Manual publish workflow for @base-org/account.
+#
+# This is the canonical workflow tied to the npm Trusted Publisher entry
+# for @base-org/account (workflow filename: release-account.yml,
+# environment: publish). The OIDC token minted by this workflow is the
+# only one npm will accept for publishing this package.
+#
+# Use this workflow to publish a specific version that was prepared (and
+# already tagged on master) by release-please but not yet pushed to npm,
+# or for any out-of-band publish.
+name: Release Account
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### _Summary_

Aligns the manual publish workflow filename with the npm Trusted Publisher entry for `@base-org/account`.

The npm Trusted Publisher for `@base-org/account` is configured for workflow filename **`release-account.yml`** with environment `publish`. The previous filename `release-account-manual.yml` caused npm to reject OIDC-authenticated publishes with a misleading 404 (npm returns 404 instead of 403 for unauthorized scope writes). This is what blocked the manual republish attempt of `@base-org/account@2.5.5` (run [25020384976](https://github.com/base/account-sdk/actions/runs/25020384976)).

After this change, the workflow can be dispatched manually to publish a version that release-please has tagged on master but not yet pushed to npm.

The `[DEPRECATED]` markers are removed since this workflow is now the canonical publish path. `release-please.yml` cannot publish until its filename is also added as a trusted publisher entry on npm — that's tracked separately.

### _How did you test your changes?_

- Verified the new filename matches the npm Trusted Publisher configuration for `@base-org/account`.
- File contents are unchanged (only the leading comment block and `name:` field were updated to remove the DEPRECATED markers).
- After merge, dispatching the workflow with `packageVersion=2.5.5` should successfully publish the missing `2.5.5` version to npm.