### PR TITLE
fix: add missing await to provider.request examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,18 +173,18 @@ yarn add @base-org/account
 3. Request accounts to initialize a connection to wallet
 
    ```js
-   const addresses = provider.request({
-     method: 'eth_requestAccounts',
-   });
+const addresses = await provider.request({
+  method: 'eth_requestAccounts',
+});
    ```
 
 4. Make more requests
 
    ```js
-   provider.request('personal_sign', [
-     `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
-     addresses[0],
-   ]);
+await provider.request('personal_sign', [
+  `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
+  addresses[0],
+]);
    ```
 
 5. Handle provider events


### PR DESCRIPTION
## Summary

Adds missing `await` calls to `provider.request()` examples in the README to ensure async usage is correct and copy-paste safe.

## Changes

* Updated README examples to use `await provider.request(...)`
* Improved consistency across examples
