### PR TITLE
fix: add fallback when crypto.randomUUID is unavailable

### DIFF
--- a/packages/account-sdk/src/util/web.ts
+++ b/packages/account-sdk/src/util/web.ts
@@ -17,12 +17,13 @@ export function openPopup(url: URL): Promise<Window> {
   appendAppInfoQueryParams(url);
 
   function tryOpenPopup(): Window | null {
-    const popupId = `wallet_${crypto.randomUUID()}`;
+  const popupId = `wallet_${
+  crypto.randomUUID?.() ?? Math.random().toString(36).slice(2)
+  }`;
     const popup = window.open(
       url,
       popupId,
-      `width=${POPUP_WIDTH}, height=${POPUP_HEIGHT}, left=${left}, top=${top}`
-    );
+      `width=${POPUP_WIDTH}, height=${POPUP_HEIGHT}, left=${left}, top=${top}`);
 
     popup?.focus();
 


### PR DESCRIPTION
## Summary

Adds a fallback popup ID generator for environments where `crypto.randomUUID()` is unavailable.

## Changes

* Added optional chaining for `crypto.randomUUID`
* Added fallback random string generation using `Math.random`
* Improves compatibility with older browsers and embedded runtimes
