### PR TITLE
docs(account-ui): fix broken framework README links

### DIFF
--- a/packages/account-ui/README.md
+++ b/packages/account-ui/README.md
@@ -19,10 +19,10 @@ npm install @base-org/account-ui
 
 For detailed usage examples and setup instructions for each framework:
 
-- **[React](./react/README.md)** - React-specific documentation and examples
-- **[Preact](./preact/README.md)** - Preact-specific documentation and examples
-- **[Vue](./vue/README.md)** - Vue-specific documentation and examples
-- **[Svelte](./svelte/README.md)** - Svelte-specific documentation and examples
+- **[React](./src/frameworks/react/README.md)** - React-specific documentation and examples
+- **[Preact](./src/frameworks/preact/README.md)** - Preact-specific documentation and examples
+- **[Vue](./src/frameworks/vue/README.md)** - Vue-specific documentation and examples
+- **[Svelte](./src/frameworks/svelte/README.md)** - Svelte-specific documentation and examples
 
 ## Quick Start - React
 


### PR DESCRIPTION
## Summary
- fix broken framework documentation links in `packages/account-ui/README.md`
- point React, Preact, Vue, and Svelte links to the existing files under `src/frameworks/`

## Test plan
- verified each updated relative link resolves to an existing file in the repository

Fixes #297
