### PR TITLE
docs: fix SDK quickstart usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ yarn add @base-org/account
 1. Initialize the SDK
 
    ```js
+   import { createBaseAccountSDK } from '@base-org/account';
+
    const sdk = createBaseAccountSDK({
      appName: 'SDK Playground',
    });
@@ -181,8 +183,10 @@ yarn add @base-org/account
 4. Make more requests
 
    ```js
+   import { stringToHex } from 'viem';
+
    provider.request('personal_sign', [
-     `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
+     stringToHex('test message'),
      addresses[0],
    ]);
    ```

--- a/packages/account-sdk/README.md
+++ b/packages/account-sdk/README.md
@@ -64,6 +64,8 @@
 1. Initialize Base Account SDK
 
    ```js
+   import { createBaseAccountSDK } from '@base-org/account';
+
    const sdk = createBaseAccountSDK({
      appName: 'SDK Playground',
    });
@@ -86,8 +88,10 @@
 4. Make more requests
 
    ```js
+   import { stringToHex } from 'viem';
+
    provider.request('personal_sign', [
-     `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
+     stringToHex('test message'),
      addresses[0],
    ]);
    ```


### PR DESCRIPTION
## Summary
- add the missing `createBaseAccountSDK` import to both quickstart snippets
- replace the Node-only `Buffer` example with the browser-safe `stringToHex` helper from `viem`

## Testing
- not run (README-only changes)
