### PR TITLE
docs(vue): add missing ref import in example

### DIFF
--- a/packages/account-ui/src/frameworks/vue/README.md
+++ b/packages/account-ui/src/frameworks/vue/README.md
@@ -165,7 +165,7 @@ If you're using TypeScript with Vue, the package includes full type definitions:
 
 <script setup lang="ts">
 import { SignInWithBaseButton } from '@base-org/account-ui/vue';
-import type { Ref } from 'vue';
+import { ref, type Ref } from 'vue';
 
 interface User {
   id: string;


### PR DESCRIPTION
## Summary
- add the missing `ref` import in the Vue TypeScript example
- keep the existing `Ref<User | null>` type annotation intact

## Testing
- not run (README-only change)
