### PR TITLE
docs(payment): fix payment README examples

### DIFF
--- a/packages/account-sdk/src/interface/payment/README.md
+++ b/packages/account-sdk/src/interface/payment/README.md
@@ -15,11 +15,7 @@ const payment = await pay({
   testnet: true
 });
 
-if (payment.success) {
-  console.log(`Payment sent! Transaction ID: ${payment.id}`);
-} else {
-  console.error(`Payment failed: ${payment.error}`);
-}
+console.log(`Payment sent! Transaction ID: ${payment.id}`);
 ```
 
 ## Checking Payment Status
@@ -27,7 +23,7 @@ if (payment.success) {
 You can check the status of a payment using the transaction ID returned from the pay function:
 
 ```typescript
-import { getPaymentStatus } from '@base/account-sdk';
+import { getPaymentStatus } from '@base-org/account';
 
 // Check payment status
 const status = await getPaymentStatus({


### PR DESCRIPTION
## Summary
- remove the unreachable error branch from the `pay()` example
- fix the `getPaymentStatus` import path to use `@base-org/account`

## Testing
- not run (README-only change)
