### PR TITLE
docs(account-cli): use workspace lint command

### DIFF
--- a/packages/account-cli/README.md
+++ b/packages/account-cli/README.md
@@ -39,7 +39,7 @@ yarn workspace @base-org/account-cli test --run
 
 ```bash
 yarn workspace @base-org/account-cli typecheck
-npx biome lint packages/account-cli/
+yarn workspace @base-org/account-cli lint
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary
- replace the direct Biome command with the package's documented workspace lint script
- keep the README aligned with `packages/account-cli/package.json`

## Testing
- not run (README-only change)
