### PR TITLE
fix(account-sdk): validate SDK config on initialization

### DIFF
--- a/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.test.ts
+++ b/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.test.ts
@@ -2,13 +2,13 @@ import * as telemetryModule from ':core/telemetry/initCCA.js';
 import { store } from ':store/store.js';
 import * as checkCrossOriginModule from ':util/checkCrossOriginOpenerPolicy.js';
 import * as validatePreferencesModule from ':util/validatePreferences.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Hex } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseAccountProvider } from './BaseAccountProvider.js';
 import {
   CreateProviderOptions,
-  createBaseAccountSDK,
   _resetGlobalInitialization,
+  createBaseAccountSDK,
 } from './createBaseAccountSDK.js';
 import * as getInjectedProviderModule from './getInjectedProvider.js';
 
@@ -37,6 +37,7 @@ vi.mock(':util/checkCrossOriginOpenerPolicy.js', () => ({
 
 vi.mock(':util/validatePreferences.js', () => ({
   validatePreferences: vi.fn(),
+  validateSDKConfig: vi.fn(),
   validateSubAccount: vi.fn(),
 }));
 
@@ -52,6 +53,7 @@ const mockStore = store as any;
 const mockLoadTelemetryScript = telemetryModule.loadTelemetryScript as any;
 const mockCheckCrossOriginOpenerPolicy = checkCrossOriginModule.checkCrossOriginOpenerPolicy as any;
 const mockValidatePreferences = validatePreferencesModule.validatePreferences as any;
+const mockValidateSDKConfig = validatePreferencesModule.validateSDKConfig as any;
 const mockValidateSubAccount = validatePreferencesModule.validateSubAccount as any;
 const mockBaseAccountProvider = BaseAccountProvider as any;
 const mockGetInjectedProvider = getInjectedProviderModule.getInjectedProvider as any;
@@ -295,6 +297,29 @@ describe('createProvider', () => {
   });
 
   describe('Validation', () => {
+    it('should validate SDK configuration before writing to the store', () => {
+      const subAccounts = { creation: 'on-connect' as const };
+
+      createBaseAccountSDK({
+        appChainIds: [8453],
+        paymasterUrls: { 8453: 'https://paymaster.example.com' },
+        subAccounts,
+      }).getProvider();
+
+      expect(mockValidateSDKConfig).toHaveBeenCalledWith(
+        {
+          metadata: {
+            appName: 'App',
+            appLogoUrl: '',
+            appChainIds: [8453],
+          },
+          preference: {},
+          paymasterUrls: { 8453: 'https://paymaster.example.com' },
+        },
+        subAccounts
+      );
+    });
+
     it('should validate preferences', () => {
       const preference = { telemetry: true };
       createBaseAccountSDK({ preference }).getProvider();
@@ -345,6 +370,23 @@ describe('createProvider', () => {
   });
 
   describe('Error handling', () => {
+    it('should not write to the store when SDK config validation fails', () => {
+      mockValidateSDKConfig.mockImplementationOnce(() => {
+        throw new Error('appChainIds[0] must be a positive integer chain ID');
+      });
+
+      expect(() => {
+        createBaseAccountSDK({
+          appChainIds: ['8453' as any],
+        });
+      }).toThrow('appChainIds[0] must be a positive integer chain ID');
+
+      expect(mockStore.subAccountsConfig.set).not.toHaveBeenCalled();
+      expect(mockStore.config.set).not.toHaveBeenCalled();
+      expect(mockStore.persist.rehydrate).not.toHaveBeenCalled();
+      expect(mockLoadTelemetryScript).not.toHaveBeenCalled();
+    });
+
     it('should handle sub-account validation errors', () => {
       mockValidateSubAccount.mockImplementationOnce(() => {
         throw new Error('Invalid sub-account function');

--- a/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
+++ b/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
@@ -12,7 +12,11 @@ import { abi } from ':sign/base-account/utils/constants.js';
 import { SubAccount, ToOwnerAccountFn, store } from ':store/store.js';
 import { assertPresence } from ':util/assertPresence.js';
 import { checkCrossOriginOpenerPolicy } from ':util/checkCrossOriginOpenerPolicy.js';
-import { validatePreferences, validateSubAccount } from ':util/validatePreferences.js';
+import {
+  validatePreferences,
+  validateSDKConfig,
+  validateSubAccount,
+} from ':util/validatePreferences.js';
 import { decodeAbiParameters, encodeFunctionData, toHex } from 'viem';
 import { BaseAccountProvider } from './BaseAccountProvider.js';
 import { getInjectedProvider } from './getInjectedProvider.js';
@@ -88,6 +92,9 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
     paymasterUrls: params.paymasterUrls,
   };
 
+  validateSDKConfig(options, params.subAccounts);
+  validatePreferences(options.preference);
+
   //  ====================================================================
   //  If we have a toOwnerAccount function, set it in the non-persisted config
   //  ====================================================================
@@ -120,8 +127,6 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
   if (options.preference.telemetry !== false) {
     initializeTelemetryOnce();
   }
-
-  validatePreferences(options.preference);
 
   //  ====================================================================
   //  Return the provider

--- a/packages/account-sdk/src/util/validatePreferences.test.ts
+++ b/packages/account-sdk/src/util/validatePreferences.test.ts
@@ -1,6 +1,10 @@
 import { ToOwnerAccountFn } from ':store/store.js';
-import { Preference } from '../core/provider/interface.js';
-import { validatePreferences, validateSubAccount } from './validatePreferences.js';
+import { ConstructorOptions, Preference, SubAccountOptions } from '../core/provider/interface.js';
+import {
+  validatePreferences,
+  validateSDKConfig,
+  validateSubAccount,
+} from './validatePreferences.js';
 
 describe('validatePreferences', () => {
   it('should not throw an error if preference is undefined', () => {
@@ -67,6 +71,100 @@ describe('validateSubAccount', () => {
   it('should not throw an error if toSubAccountSigner is a function', () => {
     const toSubAccountSigner: ToOwnerAccountFn = () => Promise.resolve({} as any);
     expect(() => validateSubAccount(toSubAccountSigner)).not.toThrow();
+  });
+});
+
+describe('validateSDKConfig', () => {
+  const validOptions: ConstructorOptions = {
+    metadata: {
+      appName: 'Test App',
+      appLogoUrl: '',
+      appChainIds: [8453, 84532],
+    },
+    preference: {},
+    paymasterUrls: {
+      8453: 'https://paymaster.example.com',
+      84532: 'http://localhost:3000/paymaster',
+    },
+  };
+
+  it('should not throw for valid SDK config', () => {
+    expect(() => validateSDKConfig(validOptions)).not.toThrow();
+  });
+
+  it('should throw when appChainIds is not an array', () => {
+    const invalidOptions = {
+      ...validOptions,
+      metadata: {
+        ...validOptions.metadata,
+        appChainIds: '8453',
+      },
+    } as any;
+
+    expect(() => validateSDKConfig(invalidOptions)).toThrow(
+      'appChainIds must be an array of positive integer chain IDs'
+    );
+  });
+
+  it('should throw when appChainIds contains an invalid chain ID', () => {
+    const invalidOptions = {
+      ...validOptions,
+      metadata: {
+        ...validOptions.metadata,
+        appChainIds: [8453, 0],
+      },
+    };
+
+    expect(() => validateSDKConfig(invalidOptions)).toThrow(
+      'appChainIds[1] must be a positive integer chain ID'
+    );
+  });
+
+  it('should throw when paymasterUrls is not an object', () => {
+    const invalidOptions = {
+      ...validOptions,
+      paymasterUrls: 'https://paymaster.example.com',
+    } as any;
+
+    expect(() => validateSDKConfig(invalidOptions)).toThrow(
+      'paymasterUrls must be an object mapping chain IDs to URLs'
+    );
+  });
+
+  it('should throw when paymasterUrls contains an invalid chain ID key', () => {
+    const invalidOptions = {
+      ...validOptions,
+      paymasterUrls: {
+        base: 'https://paymaster.example.com',
+      },
+    } as any;
+
+    expect(() => validateSDKConfig(invalidOptions)).toThrow(
+      'paymasterUrls key "base" must be a positive integer chain ID'
+    );
+  });
+
+  it('should throw when paymasterUrls contains an invalid URL', () => {
+    const invalidOptions = {
+      ...validOptions,
+      paymasterUrls: {
+        8453: 'not-a-url',
+      },
+    };
+
+    expect(() => validateSDKConfig(invalidOptions)).toThrow(
+      'paymasterUrls[8453] must be an absolute http(s) URL'
+    );
+  });
+
+  it('should throw when sub-account options contain invalid values', () => {
+    const invalidSubAccounts: SubAccountOptions = {
+      creation: 'automatic' as any,
+    };
+
+    expect(() => validateSDKConfig(validOptions, invalidSubAccounts)).toThrow(
+      'subAccounts.creation must be one of: on-connect, manual'
+    );
   });
 });
 

--- a/packages/account-sdk/src/util/validatePreferences.ts
+++ b/packages/account-sdk/src/util/validatePreferences.ts
@@ -1,5 +1,36 @@
-import { Preference } from ':core/provider/interface.js';
+import { ConstructorOptions, Preference, SubAccountOptions } from ':core/provider/interface.js';
 import { ToOwnerAccountFn } from ':store/store.js';
+
+const SUB_ACCOUNT_CREATION_MODES = ['on-connect', 'manual'] as const;
+const SUB_ACCOUNT_DEFAULT_ACCOUNTS = ['sub', 'universal'] as const;
+const SUB_ACCOUNT_FUNDING_MODES = ['spend-permissions', 'manual'] as const;
+
+function assertPositiveIntegerChainId(chainId: unknown, fieldName: string) {
+  if (!Number.isInteger(chainId) || (chainId as number) <= 0) {
+    throw new Error(`${fieldName} must be a positive integer chain ID`);
+  }
+}
+
+function assertOption<T extends readonly string[]>(value: unknown, fieldName: string, options: T) {
+  if (value !== undefined && !options.includes(value as T[number])) {
+    throw new Error(`${fieldName} must be one of: ${options.join(', ')}`);
+  }
+}
+
+function assertHttpUrl(value: unknown, fieldName: string) {
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be an absolute http(s) URL`);
+  }
+
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      throw new Error();
+    }
+  } catch {
+    throw new Error(`${fieldName} must be an absolute http(s) URL`);
+  }
+}
 
 /**
  * Validates user supplied preferences. Throws if keys are not valid.
@@ -23,6 +54,47 @@ export function validatePreferences(preference?: Preference) {
     if (typeof preference.telemetry !== 'boolean') {
       throw new Error(`Telemetry must be a boolean`);
     }
+  }
+}
+
+/**
+ * Validates SDK configuration before it is written to the store or used by providers.
+ * @param options
+ * @param subAccounts
+ */
+export function validateSDKConfig(options: ConstructorOptions, subAccounts?: SubAccountOptions) {
+  if (!Array.isArray(options.metadata.appChainIds)) {
+    throw new Error('appChainIds must be an array of positive integer chain IDs');
+  }
+
+  options.metadata.appChainIds.forEach((chainId, index) => {
+    assertPositiveIntegerChainId(chainId, `appChainIds[${index}]`);
+  });
+
+  if (options.paymasterUrls !== undefined) {
+    if (
+      typeof options.paymasterUrls !== 'object' ||
+      options.paymasterUrls === null ||
+      Array.isArray(options.paymasterUrls)
+    ) {
+      throw new Error('paymasterUrls must be an object mapping chain IDs to URLs');
+    }
+
+    Object.entries(options.paymasterUrls).forEach(([chainId, url]) => {
+      const numericChainId = Number(chainId);
+      assertPositiveIntegerChainId(numericChainId, `paymasterUrls key "${chainId}"`);
+      assertHttpUrl(url, `paymasterUrls[${chainId}]`);
+    });
+  }
+
+  if (subAccounts) {
+    assertOption(subAccounts.creation, 'subAccounts.creation', SUB_ACCOUNT_CREATION_MODES);
+    assertOption(
+      subAccounts.defaultAccount,
+      'subAccounts.defaultAccount',
+      SUB_ACCOUNT_DEFAULT_ACCOUNTS
+    );
+    assertOption(subAccounts.funding, 'subAccounts.funding', SUB_ACCOUNT_FUNDING_MODES);
   }
 }
 


### PR DESCRIPTION
Closes #210

What changed:
- Added early SDK config validation during initialization.
- Validates appChainIds, paymasterUrls, and sub-account option values before writing config to the store.
- Added unit tests for invalid config cases and fail-fast behavior.

How tested:
- yarn workspace @base-org/account test src/util/validatePreferences.test.ts src/interface/builder/core/createBaseAccountSDK.test.ts --run
- yarn workspace @base-org/account typecheck
- yarn biome check packages/account-sdk/src/util/validatePreferences.ts packages/account-sdk/src/util/validatePreferences.test.ts packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.test.ts
