### PR TITLE
docs(account-ui): fix framework README links

### DIFF
--- a/packages/account-ui/README.md
+++ b/packages/account-ui/README.md
@@ -19,10 +19,10 @@ npm install @base-org/account-ui
 
 For detailed usage examples and setup instructions for each framework:
 
-- **[React](./react/README.md)** - React-specific documentation and examples
-- **[Preact](./preact/README.md)** - Preact-specific documentation and examples
-- **[Vue](./vue/README.md)** - Vue-specific documentation and examples
-- **[Svelte](./svelte/README.md)** - Svelte-specific documentation and examples
+- **[React](./src/frameworks/react/README.md)** - React-specific documentation and examples
+- **[Preact](./src/frameworks/preact/README.md)** - Preact-specific documentation and examples
+- **[Vue](./src/frameworks/vue/README.md)** - Vue-specific documentation and examples
+- **[Svelte](./src/frameworks/svelte/README.md)** - Svelte-specific documentation and examples
 
 ## Quick Start - React
 


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
Closes #297

What changed:
- Updated framework documentation links in packages/account-ui/README.md.
- Pointed React, Preact, Vue, and Svelte links to their existing README files under src/frameworks.

How tested:
- Verified all linked README paths exist locally.
- Documentation-only change.
