### PR TITLE
fix: return undefined for empty paths in get utility

### DIFF
--- a/packages/account-sdk/src/util/get.ts
+++ b/packages/account-sdk/src/util/get.ts
@@ -1,5 +1,7 @@
 export function get(obj: unknown, path: string): unknown {
   if (typeof obj !== 'object' || obj === null) return undefined;
+  if (!path.trim()) return undefined;
+  
   return path
     .split(/[.[\]]+/)
     .filter(Boolean)


### PR DESCRIPTION
## Summary

Improves the `get` utility by handling empty or whitespace-only paths safely.

## Changes

* Added an early return for empty paths
* Prevents returning the original object when `path` is empty
* Makes utility behavior more predictable for edge cases

## Example

Before:

```ts
get(user, '')
// returned the entire object
```

After:

```ts
get(user, '')
// returns undefined
```
