### PR TITLE
test: add empty path edge case coverage for get utility

### DIFF
--- a/packages/account-sdk/src/util/get.test.ts
+++ b/packages/account-sdk/src/util/get.test.ts
@@ -10,4 +10,11 @@ describe('get', () => {
     const obj = { a: { b: { c: 'd' } } };
     expect(get(obj, 'a.b.c.d')).toBeUndefined();
   });
+  
+  it('should return undefined for empty paths', () => {
+  const obj = { a: { b: { c: 'd' } } };
+
+  expect(get(obj, '')).toBeUndefined();
+  expect(get(obj, '   ')).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Adds test coverage for empty and whitespace-only paths in the `get` utility.

## Changes

* Added tests for empty string paths
* Added tests for whitespace-only paths
* Verifies the utility returns `undefined` for invalid empty path input

## Motivation

This improves edge case coverage and ensures the utility behaves predictably for invalid path values.
