### PR TITLE
fix: prevent empty attribution dataSuffix values

### DIFF
--- a/packages/account-sdk/src/util/validatePreferences.ts
+++ b/packages/account-sdk/src/util/validatePreferences.ts
@@ -17,7 +17,13 @@ export function validatePreferences(preference?: Preference) {
     ) {
       throw new Error(`Attribution cannot contain both auto and dataSuffix properties`);
     }
-  }
+    if (
+    preference.attribution.dataSuffix !== undefined &&
+    preference.attribution.dataSuffix.trim() === ''
+    ) {
+    throw new Error(`Attribution dataSuffix cannot be empty`);
+    }
+ }
 
   if (preference.telemetry) {
     if (typeof preference.telemetry !== 'boolean') {


### PR DESCRIPTION
## Summary

Adds validation for empty `dataSuffix` values in attribution preferences.

## Changes

* Added a check for empty or whitespace-only `dataSuffix` values
* Throws a descriptive error when `dataSuffix` is invalid

## Motivation

Previously, empty strings were accepted as valid `dataSuffix` values, which could lead to invalid attribution configuration at runtime.
