### PR TITLE
fix: add TypeScript declaration for Dialog-css.js module

### DIFF
--- a/packages/account-sdk/src/ui/Dialog/Dialog-css.d.ts
+++ b/packages/account-sdk/src/ui/Dialog/Dialog-css.d.ts
@@ -1,0 +1,4 @@
+declare module './Dialog-css.js' {
+  const css: string;
+  export default css;
+}


### PR DESCRIPTION
## Summary
Adds TypeScript declaration for the `Dialog-css.js` module that is generated at build time from `Dialog.scss`.

## Problem
The build process generates `Dialog-css.ts` from `Dialog.scss` via `compile-assets.cjs`. However, TypeScript cannot find the module `./Dialog-css.js` imported in `Dialog.tsx`, causing `yarn typecheck` to fail with:


## Solution
Create a `Dialog-css.d.ts` declaration file that tells TypeScript the `.js` file exports a string (the compiled CSS).

## Files Changed
- `packages/account-sdk/src/ui/Dialog/Dialog-css.d.ts` - Added module declaration

## Testing
- `yarn typecheck` now passes without errors