### PR TITLE
chore: align @types/node version with vitest peer dependency

### DIFF
--- a/packages/account-sdk/package.json
+++ b/packages/account-sdk/package.json
@@ -156,7 +156,7 @@
     "@size-limit/preset-big-lib": "^11.1.6",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/preact": "^3.2.4",
-    "@types/node": "^14.18.54",
+    "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "2.1.2",
     "@vitest/web-worker": "3.2.1",
     "fake-indexeddb": "^6.0.0",


### PR DESCRIPTION
## Summary
Updates `@types/node` from `^14.18.54` to `^20.0.0` to satisfy vitest's peer dependency requirement.

## Problem
During `yarn install` there is a warning:


## Solution
Update `@types/node` to `^20.0.0` to align with Node 20.18.0 runtime and vitest's peer dependency requirements.

## Files Changed
- `packages/account-sdk/package.json` - Updated `@types/node` version

## Testing
- Install completes without peer dependency warnings