### PR TITLE
fix: provide randomUUID fallback for unsupported runtimes

### DIFF
--- a/packages/account-sdk/src/util/provider.ts
+++ b/packages/account-sdk/src/util/provider.ts
@@ -6,7 +6,7 @@ export async function fetchRPCRequest(request: RequestArguments, rpcUrl: string)
   const requestBody = {
     ...request,
     jsonrpc: '2.0',
-    id: crypto.randomUUID(),
+    id: crypto.randomUUID?.() ?? Math.random().toString(36).slice(2),
   };
   const res = await fetch(rpcUrl, {
     method: 'POST',


### PR DESCRIPTION
## Summary

Adds a fallback for `crypto.randomUUID()` when generating RPC request IDs.

## Changes

* Added a fallback ID generator using `Math.random`
* Prevents runtime failures in environments where `crypto.randomUUID` is unavailable

## Motivation

Some browsers and JavaScript runtimes do not support `crypto.randomUUID()`, which can cause RPC requests to fail unexpectedly.
