### PR TITLE
fix(account): tighten payment input validation

### DIFF
--- a/packages/account-sdk/src/interface/payment/subscribe.test.ts
+++ b/packages/account-sdk/src/interface/payment/subscribe.test.ts
@@ -355,3 +355,66 @@ describe('subscribe with overridePeriodInSecondsForTestnet', () => {
     expect(result.overridePeriodInSecondsForTestnet).toBeUndefined(); // Should not have overridePeriodInSecondsForTestnet on mainnet
   });
 });
+
+// Regression for https://github.com/base/account-sdk/issues/314
+describe('subscribe period validation', () => {
+  const baseOptions = {
+    recurringCharge: '10.00',
+    subscriptionOwner: '0x1234567890123456789012345678901234567890',
+  } as const;
+
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['non-integer', 1.5],
+    ['NaN', Number.NaN],
+    ['Infinity', Infinity],
+  ])('rejects %s periodInDays before any wallet interaction', async (_label, value) => {
+    await expect(
+      subscribe({
+        ...baseOptions,
+        periodInDays: value as number,
+        testnet: true,
+      })
+    ).rejects.toThrow('periodInDays must be a positive integer');
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -300],
+    ['non-integer', 1.5],
+    ['NaN', Number.NaN],
+  ])(
+    'rejects %s overridePeriodInSecondsForTestnet before any wallet interaction',
+    async (_label, value) => {
+      await expect(
+        subscribe({
+          ...baseOptions,
+          overridePeriodInSecondsForTestnet: value as number,
+          testnet: true,
+        } as SubscriptionOptions)
+      ).rejects.toThrow('overridePeriodInSecondsForTestnet must be a positive integer');
+    }
+  );
+
+  it('rejects periodInDays above uint48 max', async () => {
+    // 2^48 = 281474976710656
+    await expect(
+      subscribe({
+        ...baseOptions,
+        periodInDays: 281474976710656,
+        testnet: true,
+      })
+    ).rejects.toThrow('periodInDays must be at most');
+  });
+
+  it('rejects overridePeriodInSecondsForTestnet above uint48 max', async () => {
+    await expect(
+      subscribe({
+        ...baseOptions,
+        overridePeriodInSecondsForTestnet: 281474976710656,
+        testnet: true,
+      } as SubscriptionOptions)
+    ).rejects.toThrow('overridePeriodInSecondsForTestnet must be at most');
+  });
+});

--- a/packages/account-sdk/src/interface/payment/subscribe.ts
+++ b/packages/account-sdk/src/interface/payment/subscribe.ts
@@ -7,14 +7,19 @@ import { parseErrorMessageFromAny } from ':core/telemetry/utils.js';
 import { parseUnits } from 'viem';
 import { getHash } from '../public-utilities/spend-permission/index.js';
 import {
+  type SpendPermissionTypedData,
   createSpendPermissionTypedData,
   createSpendPermissionTypedDataWithSeconds,
-  type SpendPermissionTypedData,
 } from '../public-utilities/spend-permission/utils.js';
 import { CHAIN_IDS, TOKENS } from './constants.js';
 import type { SubscriptionOptions, SubscriptionResult } from './types.js';
 import { createEphemeralSDK } from './utils/sdkManager.js';
-import { normalizeAddress, validateStringAmount } from './utils/validation.js';
+import {
+  UINT48_MAX,
+  normalizeAddress,
+  validatePositiveSafeInteger,
+  validateStringAmount,
+} from './utils/validation.js';
 
 // Placeholder address for mutable data - will be replaced by wallet with actual account
 const PLACEHOLDER_ADDRESS = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as const;
@@ -117,6 +122,22 @@ export async function subscribe(options: SubscriptionOptions): Promise<Subscript
   try {
     // Validate inputs
     validateStringAmount(recurringCharge, 6);
+
+    // Bound the period parameter that will land in the EIP-712 typed data
+    // before we touch the wallet. uint48 is the on-chain slot width for the
+    // spend-permission period; anything outside that range (or 0, negative,
+    // fractional, NaN, Infinity) would otherwise reach wallet_sign and fail
+    // there with a far less actionable error.
+    if (testnet && overridePeriodInSecondsForTestnet !== undefined) {
+      validatePositiveSafeInteger(
+        overridePeriodInSecondsForTestnet,
+        'overridePeriodInSecondsForTestnet',
+        UINT48_MAX
+      );
+    } else {
+      validatePositiveSafeInteger(periodInDays, 'periodInDays', UINT48_MAX);
+    }
+
     const spenderAddress = normalizeAddress(subscriptionOwner);
 
     // Setup network configuration

--- a/packages/account-sdk/src/interface/payment/utils/validation.test.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeAddress, validateStringAmount } from './validation.js';
+import {
+  UINT48_MAX,
+  normalizeAddress,
+  validatePositiveSafeInteger,
+  validateStringAmount,
+} from './validation.js';
 
 describe('validateStringAmount', () => {
   it('should validate valid amounts', () => {
@@ -13,7 +18,8 @@ describe('validateStringAmount', () => {
 
   it('should reject invalid amounts', () => {
     expect(() => validateStringAmount('0', 6)).toThrow('Invalid amount: must be greater than 0');
-    expect(() => validateStringAmount('-10', 6)).toThrow('Invalid amount: must be greater than 0');
+    // Negative values fail the strict decimal format check before the >0 guard.
+    expect(() => validateStringAmount('-10', 6)).toThrow('Invalid amount: must be a valid number');
     expect(() => validateStringAmount('abc', 6)).toThrow('Invalid amount: must be a valid number');
     expect(() => validateStringAmount('10.1234567', 6)).toThrow(
       'Invalid amount: pay only supports up to 6 decimal places'
@@ -36,6 +42,98 @@ describe('validateStringAmount', () => {
     expect(() => validateStringAmount('1.123', 6)).not.toThrow();
     expect(() => validateStringAmount('1.1234', 6)).not.toThrow();
     expect(() => validateStringAmount('1.12345', 6)).not.toThrow();
+  });
+
+  // Regression for https://github.com/base/account-sdk/issues/313
+  it('should reject malformed numeric prefixes that parseFloat would silently accept', () => {
+    expect(() => validateStringAmount('1abc', 6)).toThrow('Invalid amount: must be a valid number');
+    expect(() => validateStringAmount('10x', 6)).toThrow('Invalid amount: must be a valid number');
+    expect(() => validateStringAmount('1.5usdc', 6)).toThrow(
+      'Invalid amount: must be a valid number'
+    );
+  });
+
+  it('should reject multiple decimal points', () => {
+    expect(() => validateStringAmount('1.2.3', 6)).toThrow(
+      'Invalid amount: must be a valid number'
+    );
+    expect(() => validateStringAmount('..1', 6)).toThrow('Invalid amount: must be a valid number');
+  });
+
+  it('should reject scientific notation', () => {
+    expect(() => validateStringAmount('1e5', 6)).toThrow('Invalid amount: must be a valid number');
+    expect(() => validateStringAmount('1E-3', 6)).toThrow('Invalid amount: must be a valid number');
+  });
+
+  it('should reject explicit signs and surrounding whitespace', () => {
+    expect(() => validateStringAmount('+1', 6)).toThrow('Invalid amount: must be a valid number');
+    expect(() => validateStringAmount(' 1', 6)).toThrow('Invalid amount: must be a valid number');
+    expect(() => validateStringAmount('1 ', 6)).toThrow('Invalid amount: must be a valid number');
+  });
+
+  it('should reject leading or trailing decimal point', () => {
+    expect(() => validateStringAmount('.5', 6)).toThrow('Invalid amount: must be a valid number');
+    expect(() => validateStringAmount('5.', 6)).toThrow('Invalid amount: must be a valid number');
+  });
+
+  it('should reject the empty string', () => {
+    expect(() => validateStringAmount('', 6)).toThrow('Invalid amount: must be a valid number');
+  });
+});
+
+// Regression for https://github.com/base/account-sdk/issues/314
+describe('validatePositiveSafeInteger', () => {
+  it('should accept positive integers in range', () => {
+    expect(() => validatePositiveSafeInteger(1, 'periodInDays')).not.toThrow();
+    expect(() => validatePositiveSafeInteger(30, 'periodInDays')).not.toThrow();
+    expect(() =>
+      validatePositiveSafeInteger(UINT48_MAX, 'periodInSeconds', UINT48_MAX)
+    ).not.toThrow();
+  });
+
+  it('should reject zero and negative values', () => {
+    expect(() => validatePositiveSafeInteger(0, 'periodInDays')).toThrow(
+      'periodInDays must be a positive integer'
+    );
+    expect(() => validatePositiveSafeInteger(-1, 'periodInDays')).toThrow(
+      'periodInDays must be a positive integer'
+    );
+  });
+
+  it('should reject non-integer numeric values', () => {
+    expect(() => validatePositiveSafeInteger(1.5, 'periodInDays')).toThrow(
+      'periodInDays must be a positive integer'
+    );
+    expect(() => validatePositiveSafeInteger(Number.NaN, 'periodInDays')).toThrow(
+      'periodInDays must be a positive integer'
+    );
+    expect(() => validatePositiveSafeInteger(Infinity, 'periodInDays')).toThrow(
+      'periodInDays must be a positive integer'
+    );
+  });
+
+  it('should reject non-number types including string-looking numbers', () => {
+    expect(() => validatePositiveSafeInteger('30' as unknown as number, 'periodInDays')).toThrow(
+      'periodInDays must be a positive integer'
+    );
+    expect(() => validatePositiveSafeInteger(null as unknown as number, 'periodInDays')).toThrow(
+      'periodInDays must be a positive integer'
+    );
+    expect(() =>
+      validatePositiveSafeInteger(undefined as unknown as number, 'periodInDays')
+    ).toThrow('periodInDays must be a positive integer');
+  });
+
+  it('should enforce the optional upper bound', () => {
+    expect(() =>
+      validatePositiveSafeInteger(UINT48_MAX + 1, 'periodInSeconds', UINT48_MAX)
+    ).toThrow(`periodInSeconds must be at most ${UINT48_MAX}`);
+  });
+
+  it('should reject unsafe integers above Number.MAX_SAFE_INTEGER even without an upper bound', () => {
+    expect(() => validatePositiveSafeInteger(Number.MAX_SAFE_INTEGER + 2, 'periodInDays')).toThrow(
+      'periodInDays must be a positive integer'
+    );
   });
 });
 

--- a/packages/account-sdk/src/interface/payment/utils/validation.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.ts
@@ -1,7 +1,36 @@
 import { type Address, type Hex, getAddress, isHex } from 'viem';
 
 /**
- * Validates that the amount is a positive string with max decimal places
+ * Maximum value for uint48, the on-chain slot width used by spend
+ * permissions for period and timestamp fields. Exposed so callers can
+ * bound user input (e.g. periodInDays, periodInSeconds) against the
+ * exact range the contract accepts.
+ */
+export const UINT48_MAX = 281474976710655; // 2^48 - 1
+
+/**
+ * Strict decimal-string format: one or more digits, optionally followed
+ * by a single '.' and one or more decimal digits. Rejects negatives,
+ * explicit '+', scientific notation, leading/trailing '.', surrounding
+ * whitespace, the empty string, and trailing non-numeric characters that
+ * `parseFloat` would silently truncate (e.g. "1abc", "1.2.3").
+ *
+ * Pattern carries no anchors-by-default behavior—`test()` already
+ * anchors via the explicit '^' and '$'.
+ */
+const STRICT_DECIMAL_RE = /^\d+(\.\d+)?$/;
+
+/**
+ * Validates that the amount is a positive string with max decimal places.
+ *
+ * Format rules (see {@link STRICT_DECIMAL_RE} for the regex):
+ *   - Must be a `string`.
+ *   - Must match a strict decimal literal—no signs, whitespace, or
+ *     scientific notation. This closes a gap where `parseFloat` would
+ *     accept "1abc" or "1.2.3" by reading only the numeric prefix.
+ *   - Numeric value must be greater than 0.
+ *   - Fractional part, if present, must be at most `maxDecimals` digits.
+ *
  * @param amount - The amount to validate as a string
  * @param maxDecimals - Maximum number of decimal places allowed
  * @throws Error if amount is invalid
@@ -11,11 +40,12 @@ export function validateStringAmount(amount: string, maxDecimals: number): void 
     throw new Error('Invalid amount: must be a string');
   }
 
-  const numAmount = parseFloat(amount);
-
-  if (isNaN(numAmount)) {
+  if (!STRICT_DECIMAL_RE.test(amount)) {
     throw new Error('Invalid amount: must be a valid number');
   }
+
+  // Safe to parse now that the format is known to be a plain decimal.
+  const numAmount = Number(amount);
 
   if (numAmount <= 0) {
     throw new Error('Invalid amount: must be greater than 0');
@@ -28,6 +58,27 @@ export function validateStringAmount(amount: string, maxDecimals: number): void 
     if (decimalPlaces > maxDecimals) {
       throw new Error(`Invalid amount: pay only supports up to ${maxDecimals} decimal places`);
     }
+  }
+}
+
+/**
+ * Validates that `value` is a positive, finite, safe integer—and optionally
+ * within an inclusive upper bound. Used to harden parameters that eventually
+ * land in EIP-712 typed data slots (e.g. spend-permission period fields), so
+ * malformed inputs can't reach the wallet signing step.
+ *
+ * @param value - Candidate value (untyped on purpose; this is a runtime guard)
+ * @param fieldName - Human-readable field name surfaced in the error message
+ * @param max - Optional inclusive upper bound (e.g. {@link UINT48_MAX})
+ * @throws Error if `value` is not a positive safe integer, or exceeds `max`
+ */
+export function validatePositiveSafeInteger(value: unknown, fieldName: string, max?: number): void {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${fieldName} must be a positive integer`);
+  }
+
+  if (max !== undefined && value > max) {
+    throw new Error(`${fieldName} must be at most ${max}`);
   }
 }
 


### PR DESCRIPTION
## Summary

Two bugs in `@base-org/account` payment validation, fixed together because they share `validation.ts`:

- **#313** — `validateStringAmount` used `parseFloat`, which silently accepts inputs like `"1abc"` or `"1.2.3"` by reading only the numeric prefix. The function now requires a strict decimal literal `^\d+(\.\d+)?$`, so malformed amounts fail immediately with a clear error rather than reaching downstream payment encoding with a truncated value.
- **#314** — `subscribe()` did not bound `periodInDays` or `overridePeriodInSecondsForTestnet`, so `0`, negative, fractional, `NaN`, `Infinity`, or values above `uint48` could reach `wallet_sign`. A new `validatePositiveSafeInteger(value, fieldName, max?)` helper enforces a positive safe integer (optionally bounded by `UINT48_MAX = 281474976710655`), called at the same point as the existing input validation in `subscribe()`.

`pay()` benefits from the stricter `validateStringAmount` automatically, since it calls the same validator.

## Changes

| File | Change |
|---|---|
| `validation.ts` | `STRICT_DECIMAL_RE` rejects malformed/scientific/whitespace; `validatePositiveSafeInteger` helper; `UINT48_MAX` constant exported |
| `subscribe.ts` | Imports the new helper; validates the active period parameter before any wallet interaction |
| `validation.test.ts` | +12 assertions: malformed prefixes, multiple dots, scientific notation, signs, whitespace, leading/trailing dot, empty; full coverage of `validatePositiveSafeInteger` (positive/zero/negative/non-integer/non-number/max-bound/unsafe-integer) |
| `subscribe.test.ts` | +11 assertions: `it.each` over both period parameters for zero/negative/non-integer/NaN/Infinity; uint48 upper-bound rejection |

## Behavior changes worth noting

- `validateStringAmount("-10", 6)` previously threw `"Invalid amount: must be greater than 0"`; now throws `"Invalid amount: must be a valid number"`. Still rejects negatives — the message is just more accurate (negative-sign also fails the strict-decimal format check first). Existing test updated.
- No other public-API surface changes; new exports (`validatePositiveSafeInteger`, `UINT48_MAX`) are additive.

## Test Plan

- `yarn vitest run src/interface/payment/utils/validation.test.ts src/interface/payment/subscribe.test.ts` → **42 / 42 passing**.
- Wider payment suite still passes the 177 tests that were green on `master`; two test files (`pay.test.ts`, `base.test.ts`) fail at the Vite transform stage with `Failed to resolve import "./Dialog-css.js"` — verified to fail identically on the unmodified `master` baseline (pre-existing).
- `biome check --write` applied to the four touched files; no new diagnostics from my diff.

Closes #313
Closes #314