### PR TITLE
fix: prevent hanging COOP validation requests

### DIFF
--- a/packages/account-sdk/src/util/checkCrossOriginOpenerPolicy.ts
+++ b/packages/account-sdk/src/util/checkCrossOriginOpenerPolicy.ts
@@ -37,8 +37,16 @@ const createCoopChecker = () => {
 
       try {
         const url = `${window.location.origin}${window.location.pathname}`;
-        const response = await fetch(url, {
-          method: 'HEAD',
+        
+const controller = new AbortController();
+
+const timeout = window.setTimeout(() => {
+  controller.abort();
+}, 5000);
+
+       const response = await fetch(url, {
+       method: 'HEAD',
+       signal: controller.signal,
         });
 
         if (!response.ok) {
@@ -55,6 +63,9 @@ const createCoopChecker = () => {
         console.error('Error checking Cross-Origin-Opener-Policy:', (error as Error).message);
         crossOriginOpenerPolicy = 'error';
       }
+      finally {
+  window.clearTimeout(timeout);
+}
     },
   };
 };


### PR DESCRIPTION
## Summary

Adds timeout handling for Cross-Origin-Opener-Policy validation requests.

## Changes

* Added `AbortController` support for COOP fetch requests
* Automatically aborts stalled requests after 5 seconds
* Moved timeout cleanup into a `finally` block for safer resource handling

## Motivation

Previously, stalled or hanging network requests could leave COOP validation unresolved indefinitely. This change improves runtime reliability and prevents lingering timeout handlers.
