### PR TITLE
fix(payment): validate subscription periods and tighten amount parsing

### DIFF
--- a/packages/account-sdk/src/interface/payment/subscribe.ts
+++ b/packages/account-sdk/src/interface/payment/subscribe.ts
@@ -14,7 +14,7 @@ import {
 import { CHAIN_IDS, TOKENS } from './constants.js';
 import type { SubscriptionOptions, SubscriptionResult } from './types.js';
 import { createEphemeralSDK } from './utils/sdkManager.js';
-import { normalizeAddress, validateStringAmount } from './utils/validation.js';
+import { normalizeAddress, validatePeriodInDays, validatePeriodInSeconds, validateStringAmount } from './utils/validation.js';
 
 // Placeholder address for mutable data - will be replaced by wallet with actual account
 const PLACEHOLDER_ADDRESS = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as const;
@@ -118,6 +118,10 @@ export async function subscribe(options: SubscriptionOptions): Promise<Subscript
     // Validate inputs
     validateStringAmount(recurringCharge, 6);
     const spenderAddress = normalizeAddress(subscriptionOwner);
+    validatePeriodInDays(periodInDays);
+    if (overridePeriodInSecondsForTestnet !== undefined) {
+      validatePeriodInSeconds(overridePeriodInSecondsForTestnet);
+    }
 
     // Setup network configuration
     const network = testnet ? 'baseSepolia' : 'base';

--- a/packages/account-sdk/src/interface/payment/utils/validation.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.ts
@@ -11,9 +11,16 @@ export function validateStringAmount(amount: string, maxDecimals: number): void 
     throw new Error('Invalid amount: must be a string');
   }
 
-  const numAmount = parseFloat(amount);
+  // Use a regex to validate the format before parsing
+  // This prevents parseFloat from accepting malformed strings like "1abc"
+  const trimmed = amount.trim();
+  if (!/^-?\d+(\.\d+)?$/.test(trimmed)) {
+    throw new Error('Invalid amount: must be a valid decimal number');
+  }
 
-  if (isNaN(numAmount)) {
+  const numAmount = parseFloat(trimmed);
+
+  if (isNaN(numAmount) || !isFinite(numAmount)) {
     throw new Error('Invalid amount: must be a valid number');
   }
 
@@ -22,12 +29,38 @@ export function validateStringAmount(amount: string, maxDecimals: number): void 
   }
 
   // Only allow specified decimal places
-  const decimalIndex = amount.indexOf('.');
+  const decimalIndex = trimmed.indexOf('.');
   if (decimalIndex !== -1) {
-    const decimalPlaces = amount.length - decimalIndex - 1;
+    const decimalPlaces = trimmed.length - decimalIndex - 1;
     if (decimalPlaces > maxDecimals) {
       throw new Error(`Invalid amount: pay only supports up to ${maxDecimals} decimal places`);
     }
+  }
+}
+
+/**
+ * Validates that periodInDays is a positive safe integer
+ * @param periodInDays - The period in days to validate
+ * @throws Error if period is invalid
+ */
+export function validatePeriodInDays(periodInDays: number): void {
+  if (!Number.isSafeInteger(periodInDays) || periodInDays <= 0) {
+    throw new Error(
+      `Invalid periodInDays: must be a positive integer (received ${periodInDays})`
+    );
+  }
+}
+
+/**
+ * Validates that periodInSeconds is a positive safe integer
+ * @param periodInSeconds - The period in seconds to validate
+ * @throws Error if period is invalid
+ */
+export function validatePeriodInSeconds(periodInSeconds: number): void {
+  if (!Number.isSafeInteger(periodInSeconds) || periodInSeconds <= 0) {
+    throw new Error(
+      `Invalid periodInSeconds: must be a positive integer (received ${periodInSeconds})`
+    );
   }
 }
 


### PR DESCRIPTION
Closes #314
Closes #313

## Changes

### 1. Tightened `validateStringAmount()` (#313)
- Added regex validation (`/^-?\d+(\.\d+)?$/`) before `parseFloat()` to reject malformed strings like `"1abc"`, `"1.2.3"`, `"1foo"`
- Added `isFinite()` check to reject `Infinity` values
- Trimmed input before validation for consistency

### 2. Added period validation functions (#314)
- `validatePeriodInDays()` — rejects zero, negative, non-integer, NaN, and Infinity values
- `validatePeriodInSeconds()` — same validation for seconds-based periods

### 3. Applied period validation in `subscribe()`
- Validates `periodInDays` before creating spend permission typed data
- Validates `overridePeriodInSecondsForTestnet` when present (testnet mode)
- Validation runs early, before wallet signing, to fail fast with clear error messages

## Testing
```typescript
// These now throw clear errors instead of reaching wallet signing:
await subscribe({ recurringCharge: "10", subscriptionOwner: "...", periodInDays: 0 });
// → Error: Invalid periodInDays: must be a positive integer (received 0)

await subscribe({ recurringCharge: "10", subscriptionOwner: "...", periodInDays: -5 });
// → Error: Invalid periodInDays: must be a positive integer (received -5)

await subscribe({ recurringCharge: "1abc", subscriptionOwner: "..." });
// → Error: Invalid amount: must be a valid decimal number
```