### PR TITLE
docs(readme): add missing await on provider.request() examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ yarn add @base-org/account
 3. Request accounts to initialize a connection to wallet
 
    ```js
-   const addresses = provider.request({
+   const addresses = await provider.request({
      method: 'eth_requestAccounts',
    });
    ```
@@ -181,7 +181,7 @@ yarn add @base-org/account
 4. Make more requests
 
    ```js
-   provider.request('personal_sign', [
+   await provider.request('personal_sign', [
      `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
      addresses[0],
    ]);

--- a/packages/account-sdk/README.md
+++ b/packages/account-sdk/README.md
@@ -78,7 +78,7 @@
 3. Request accounts to initialize a connection to wallet
 
    ```js
-   const addresses = provider.request({
+   const addresses = await provider.request({
      method: 'eth_requestAccounts',
    });
    ```
@@ -86,7 +86,7 @@
 4. Make more requests
 
    ```js
-   provider.request('personal_sign', [
+   await provider.request('personal_sign', [
      `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
      addresses[0],
    ]);


### PR DESCRIPTION
Closes #272

## Summary
Two `provider.request()` calls in the README examples are missing `await`. Since `provider.request()` returns a Promise, anyone copying these examples would get unresolved Promises instead of actual values.

## Changes
- Root README.md: Added `await` to `eth_requestAccounts` and `personal_sign` examples
- packages/account-sdk/README.md: Same fix in the package-level README

## Before
```js
const addresses = provider.request({ method: 'eth_requestAccounts' });
provider.request('personal_sign', [...]);
```

## After
```js
const addresses = await provider.request({ method: 'eth_requestAccounts' });
await provider.request('personal_sign', [...]);
```