### PR TITLE
fix(spend-permission): use wallet-signed data for returned permission

### DIFF
--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/requestSpendPermission.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/requestSpendPermission.ts
@@ -78,6 +78,7 @@ const requestSpendPermissionFn = async (
   // Check if we should use wallet_sign (when capabilities are provided) or eth_signTypedData_v4
   let signature: string;
   let permissionHash: string;
+  let signedMessage = typedData.message;
 
   if (capabilities) {
     // Use wallet_sign with capabilities
@@ -122,8 +123,9 @@ const requestSpendPermissionFn = async (
     };
 
     signature = signResult.signature;
+    signedMessage = signResult.signedData.message;
     permissionHash = await getHash({
-      permission: signResult.signedData.message,
+      permission: signedMessage,
       chainId,
     });
   } else {
@@ -142,7 +144,7 @@ const requestSpendPermissionFn = async (
     permissionHash,
     signature,
     chainId,
-    permission: typedData.message,
+    permission: signedMessage,
   };
 
   return permission;


### PR DESCRIPTION
Fixes #324

## Problem
`requestSpendPermission` uses `mutableData: { fields: ['message.account'] }` to allow the wallet to substitute the account address (e.g., replacing an EOA with a smart-wallet). However, the returned `SpendPermission` object uses the **original** pre-substitution `typedData.message` for the `permission` field, while correctly using the **post-substitution** `signResult.signedData.message` for `permissionHash`.

This produces an internally inconsistent object:
```
result.permissionHash  → hash of { account: 0xSmartWallet, ... }  // correct
result.permission.account → 0xCallerEOA                           // WRONG
```

## Fix
Track the actual signed message and use it consistently:
- Introduced `signedMessage` variable initialized to `typedData.message`
- In the `wallet_sign` path, update `signedMessage = signResult.signedData.message`
- Use `signedMessage` in the returned `SpendPermission` object

This ensures `permission.account` always matches the account in `permissionHash`, regardless of whether the wallet performed a substitution.

## Testing
The existing test mocks `signedData` as the same object as `typedData`, so no substitution occurs. A test where `signedData.message.account` differs from the request `account` would expose the inconsistency. This fix makes such a test pass correctly.