### PR TITLE
fix(signer): throw error instead of returning in sendRequestToSubAccountSigner

### DIFF
--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -792,7 +792,7 @@ export class Signer {
           correlationId,
           errorMessage: parseErrorMessageFromAny(error),
         });
-        return standardErrors.provider.unauthorized(
+        throw standardErrors.provider.unauthorized(
           'failed to add sub account owner when sending request to sub account signer'
         );
       }


### PR DESCRIPTION
## Summary

The catch block in `sendRequestToSubAccountSigner` (Signer.ts:789-798) uses `return` instead of `throw` when `handleAddSubAccountOwner` fails. This causes the Error object to be silently returned as a value instead of propagating the error to the caller.

**Impact:** Sub-account owner addition failures are silently swallowed, making it appear the operation succeeded when it actually failed.

## Fix

Changed `return standardErrors.provider.unauthorized(...)` to `throw standardErrors.provider.unauthorized(...)` to properly propagate the error.

## Test Plan

- [ ] Existing tests pass
- [ ] Verify that sub-account owner addition failures now properly surface to callers

Closes #326