### PR TITLE
fix(spend-permission): throw in production guard instead of console.warn

### DIFF
--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/utils.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/utils.ts
@@ -124,9 +124,9 @@ export function createSpendPermissionTypedDataWithSeconds(
 
   // Runtime check to prevent misuse
   if (process.env.NODE_ENV === 'production') {
-    console.warn(
-      '⚠️ createSpendPermissionTypedDataWithSeconds is being used. ' +
-        'This function is intended for testing purposes only.'
+    throw new Error(
+      'createSpendPermissionTypedDataWithSeconds is intended for testing purposes only. ' +
+        'Use createSpendPermissionTypedData for production.'
     );
   }
 


### PR DESCRIPTION
## Summary

The production guard in `createSpendPermissionTypedDataWithSeconds` (utils.ts:126-131) uses `console.warn` which only logs a warning but allows the test-only function to execute in production.

**Impact:** The `@testOnly` function can be accidentally used in production without any hard failure, potentially causing incorrect spend permission behavior with raw seconds instead of days.

## Fix

Changed `console.warn(...)` to `throw new Error(...)` to prevent silent misuse in production environments.

## Test Plan

- [ ] Existing tests pass
- [ ] Verify that calling this function in production mode throws an Error

Closes #325