### PR TITLE
fix: throw error instead of warning for test-only function in production

### DIFF
--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/utils.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/utils.ts
@@ -124,9 +124,9 @@ export function createSpendPermissionTypedDataWithSeconds(
 
   // Runtime check to prevent misuse
   if (process.env.NODE_ENV === 'production') {
-    console.warn(
-      '⚠️ createSpendPermissionTypedDataWithSeconds is being used. ' +
-        'This function is intended for testing purposes only.'
+    throw new Error(
+      'createSpendPermissionTypedDataWithSeconds is for testing only and must not be called in production. ' +
+        'Use createSpendPermissionTypedData with periodInDays instead.'
     );
   }
 


### PR DESCRIPTION
## Summary

Changes `createSpendPermissionTypedDataWithSeconds` production guard from soft `console.warn` to hard `throw`.

## Problem (Issue #325)

Current production guard is ineffective:

```ts
if (process.env.NODE_ENV === 'production') {
  console.warn(
    '⚠️ createSpendPermissionTypedDataWithSeconds is being used. ' +
      'This function is intended for testing purposes only.'
  );
}
// Function continues and returns valid SpendPermissionTypedData
```

**Issues:**
- `console.warn` is invisible to end-users
- Silently swallowed by logging pipelines
- Function continues execution regardless
- Returns valid typed data that can be signed and submitted on-chain

## Security Risk

Spend permissions authorize **recurring token withdrawals** from user accounts. This test utility creates permissions with arbitrary **second-level periods** (not day-level like production).

**Attack scenarios:**
1. **Accidental misuse**: Developer copies test code to production, creates 60-second period instead of 60-day
2. **Rapid drainage**: Very short periods drain allowances much faster than intended
3. **UX mismatch**: Production UI doesn't support second-level periods, causing confusion

## Solution

Replace with hard error:

```ts
if (process.env.NODE_ENV === 'production') {
  throw new Error(
    'createSpendPermissionTypedDataWithSeconds is for testing only and must not be called in production. ' +
      'Use createSpendPermissionTypedData with periodInDays instead.'
  );
}
```

## Impact

✅ **Production callers fail fast and loudly**
✅ **Prevents accidental misuse**
✅ **Aligns with `@testOnly` JSDoc intent**
✅ **No breaking change for correct usage** (test-only)

## Testing

- No existing tests use this function (verified with grep)
- CI will verify no regressions
- Function is already marked `@testOnly` in JSDoc

Fixes #325