### PR TITLE
export: export SAFETY_BUFFER_PER_CALL and PROPORTIONAL_INPUT_COST_PER_BYTE

### DIFF
--- a/packages/account-sdk/src/core/message/RPCMessage.test.ts
+++ b/packages/account-sdk/src/core/message/RPCMessage.test.ts
@@ -1,0 +1,441 @@
+import { describe, expect, it, vi } from 'vitest';
+import { standardErrors } from ':core/error/errors.js';
+import { ConfigMessage, ConfigEvent } from './ConfigMessage.js';
+import {
+  EncryptedData,
+  RPCRequestMessage,
+  RPCResponseMessage,
+} from './RPCMessage.js';
+import { RPCRequest } from './RPCRequest.js';
+import { RPCResponse } from './RPCResponse.js';
+import { MessageID } from './Message.js';
+
+// Mock cipher utilities to isolate serialization tests from crypto
+vi.mock(':util/cipher', () => ({
+  encryptContent: vi.fn().mockImplementation(async (content) => ({
+    iv: new Uint8Array(12),
+    cipherText: new TextEncoder().encode(JSON.stringify(content)).buffer,
+  })),
+  decryptContent: vi.fn().mockImplementation(async (encryptedData) => {
+    const text = new TextDecoder().decode(
+      encryptedData.cipherText instanceof ArrayBuffer
+        ? encryptedData.cipherText
+        : encryptedData.cipherText
+    );
+    return JSON.parse(text);
+  }),
+}));
+
+const mockIv = new Uint8Array(12);
+const mockCipherText = (content: unknown): ArrayBuffer =>
+  new TextEncoder().encode(JSON.stringify(content)).buffer;
+
+const MOCK_ID = '00000000-0000-0000-0000-000000000001' as MessageID;
+const MOCK_CORRELATION_ID = '00000000-0000-0000-0000-000000000002' as MessageID;
+const MOCK_REQUEST_ID = '00000000-0000-0000-0000-000000000003' as MessageID;
+const MOCK_SENDER = '0x04a0a9b7c4e7f3b5c1d6e8f0a2b4c6d8e0f1a3b5c7d9e1f3a5b7c9d1e3f5a7';
+
+describe('RPCMessage serialization roundtrip', () => {
+  describe('RPCRequestMessage', () => {
+    it('should serialize and deserialize a handshake request', async () => {
+      const request: RPCRequest = {
+        action: { method: 'eth_requestAccounts' },
+        chainId: 1,
+      };
+
+      const envelope: RPCRequestMessage = {
+        id: MOCK_ID,
+        correlationId: MOCK_CORRELATION_ID,
+        sender: MOCK_SENDER,
+        content: { handshake: request.action },
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+      };
+
+      // Simulate serialization: JSON.stringify (what encryptContent does internally)
+      const serialized = JSON.stringify(envelope);
+      const deserialized = JSON.parse(serialized) as RPCRequestMessage;
+
+      expect(deserialized.id).toBe(MOCK_ID);
+      expect(deserialized.correlationId).toBe(MOCK_CORRELATION_ID);
+      expect(deserialized.sender).toBe(MOCK_SENDER);
+      expect(deserialized.content).toEqual({ handshake: request.action });
+      expect(deserialized.timestamp).toBe('2024-01-01T00:00:00.000Z');
+    });
+
+    it('should serialize and deserialize an encrypted request', async () => {
+      const encryptedData: EncryptedData = {
+        iv: mockIv,
+        cipherText: mockCipherText({ result: { value: '0xabc' } }),
+      };
+
+      const envelope: RPCRequestMessage = {
+        id: MOCK_ID,
+        correlationId: MOCK_CORRELATION_ID,
+        sender: MOCK_SENDER,
+        content: { encrypted: encryptedData },
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+      };
+
+      const serialized = JSON.stringify(envelope);
+      const deserialized = JSON.parse(serialized) as RPCRequestMessage;
+
+      expect(deserialized.id).toBe(MOCK_ID);
+      expect(deserialized.content).toHaveProperty('encrypted');
+      expect((deserialized.content as { encrypted: EncryptedData }).encrypted).toHaveProperty('iv');
+      expect((deserialized.content as { encrypted: EncryptedData }).encrypted).toHaveProperty('cipherText');
+    });
+
+    it('should preserve undefined correlationId', () => {
+      const envelope: RPCRequestMessage = {
+        id: MOCK_ID,
+        correlationId: undefined,
+        sender: MOCK_SENDER,
+        content: { handshake: { method: 'handshake' } },
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+      };
+
+      const serialized = JSON.stringify(envelope);
+      const deserialized = JSON.parse(serialized) as RPCRequestMessage;
+
+      expect(deserialized.correlationId).toBeUndefined();
+    });
+  });
+
+  describe('RPCResponseMessage', () => {
+    it('should serialize and deserialize a success response with encrypted content', async () => {
+      const encryptedData: EncryptedData = {
+        iv: mockIv,
+        cipherText: mockCipherText({ result: { value: '0xSignature' } }),
+      };
+
+      const envelope: RPCResponseMessage = {
+        id: MOCK_ID,
+        correlationId: MOCK_CORRELATION_ID,
+        requestId: MOCK_REQUEST_ID,
+        sender: MOCK_SENDER,
+        content: { encrypted: encryptedData },
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+      };
+
+      const serialized = JSON.stringify(envelope);
+      const deserialized = JSON.parse(serialized) as RPCResponseMessage;
+
+      expect(deserialized.id).toBe(MOCK_ID);
+      expect(deserialized.requestId).toBe(MOCK_REQUEST_ID);
+      expect(deserialized.content).toHaveProperty('encrypted');
+    });
+
+    it('should serialize and deserialize a failure response', async () => {
+      const error = standardErrors.provider.userRejectedRequest();
+
+      const envelope: RPCResponseMessage = {
+        id: MOCK_ID,
+        correlationId: MOCK_CORRELATION_ID,
+        requestId: MOCK_REQUEST_ID,
+        sender: MOCK_SENDER,
+        content: { failure: error },
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+      };
+
+      const serialized = JSON.stringify(envelope);
+      const deserialized = JSON.parse(serialized) as RPCResponseMessage;
+
+      expect(deserialized.content).toHaveProperty('failure');
+      const failure = (deserialized.content as { failure: unknown }).failure;
+      expect(failure).toHaveProperty('code');
+      expect(failure).toHaveProperty('message');
+    });
+
+    it('should preserve requestId in failure response', () => {
+      const error = standardErrors.rpc.internal('server error');
+
+      const envelope: RPCResponseMessage = {
+        id: MOCK_ID,
+        correlationId: MOCK_CORRELATION_ID,
+        requestId: MOCK_REQUEST_ID,
+        sender: MOCK_SENDER,
+        content: { failure: error },
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+      };
+
+      const serialized = JSON.stringify(envelope);
+      const deserialized = JSON.parse(serialized) as RPCResponseMessage;
+
+      expect(deserialized.requestId).toBe(MOCK_REQUEST_ID);
+    });
+  });
+
+  describe('malformed envelope handling', () => {
+    it('should reject envelope with missing required fields', () => {
+      const incompleteEnvelope = {
+        id: MOCK_ID,
+        // missing sender, content, timestamp
+      };
+
+      const serialized = JSON.stringify(incompleteEnvelope);
+      const deserialized = JSON.parse(serialized);
+
+      expect(deserialized.sender).toBeUndefined();
+      expect(deserialized.content).toBeUndefined();
+    });
+
+    it('should handle empty string payload', () => {
+      expect(() => {
+        JSON.parse('');
+      }).toThrow();
+    });
+
+    it('should handle non-JSON payload', () => {
+      const serialized = 'not valid json at all';
+      expect(() => {
+        JSON.parse(serialized);
+      }).toThrow();
+    });
+
+    it('should handle null payload', () => {
+      const deserialized = JSON.parse('null');
+      expect(deserialized).toBeNull();
+    });
+
+    it('should handle array payload instead of object', () => {
+      const arr = [{ id: MOCK_ID }];
+      const serialized = JSON.stringify(arr);
+      const deserialized = JSON.parse(serialized);
+
+      expect(Array.isArray(deserialized)).toBe(true);
+      expect(deserialized[0].id).toBe(MOCK_ID);
+    });
+  });
+
+  describe('ConfigMessage type dispatch', () => {
+    it('should serialize and deserialize PopupLoaded event', () => {
+      const configMsg: ConfigMessage = {
+        id: MOCK_ID,
+        event: 'PopupLoaded',
+        data: { timestamp: 1234567890 },
+      };
+
+      const serialized = JSON.stringify(configMsg);
+      const deserialized = JSON.parse(serialized) as ConfigMessage;
+
+      expect(deserialized.event).toBe('PopupLoaded');
+      expect(deserialized.data).toEqual({ timestamp: 1234567890 });
+    });
+
+    it('should serialize and deserialize PopupUnload event', () => {
+      const configMsg: ConfigMessage = {
+        id: MOCK_ID,
+        event: 'PopupUnload',
+        data: { reason: 'user-initiated' },
+      };
+
+      const serialized = JSON.stringify(configMsg);
+      const deserialized = JSON.parse(serialized) as ConfigMessage;
+
+      expect(deserialized.event).toBe('PopupUnload');
+    });
+
+    it('should preserve ConfigEvent literal types', () => {
+      const events: ConfigEvent[] = ['PopupLoaded', 'PopupUnload'];
+
+      for (const event of events) {
+        const configMsg: ConfigMessage = { id: MOCK_ID, event };
+        const serialized = JSON.stringify(configMsg);
+        const deserialized = JSON.parse(serialized) as ConfigMessage;
+        expect(deserialized.event).toBe(event);
+      }
+    });
+  });
+
+  describe('error encoding/decoding', () => {
+    it('should roundtrip a standard RPC error', () => {
+      const error = standardErrors.rpc.invalidParams('missing method');
+
+      const serialized = JSON.stringify(error);
+      const deserialized = JSON.parse(serialized);
+
+      expect(deserialized.code).toBe(error.code);
+      expect(deserialized.message).toBe(error.message);
+    });
+
+    it('should roundtrip a provider error with data', () => {
+      const error = standardErrors.provider.userRejectedRequest({
+        message: 'rejected',
+        data: { cause: 'user-denied' },
+      });
+
+      const serialized = JSON.stringify(error);
+      const deserialized = JSON.parse(serialized);
+
+      expect(deserialized.code).toBe(error.code);
+      expect(deserialized.message).toBe('rejected');
+      expect(deserialized.data).toEqual({ cause: 'user-denied' });
+    });
+
+    it('should roundtrip an error with stack when shouldIncludeStack is true', () => {
+      const error = standardErrors.rpc.internal('something went wrong');
+      const withStack = { ...error, stack: 'Error\n at someFunction (file.js:10)' };
+
+      const serialized = JSON.stringify(withStack);
+      const deserialized = JSON.parse(serialized);
+
+      expect(deserialized.stack).toBeDefined();
+    });
+
+    it('should handle error with no message gracefully', () => {
+      const malformedError = { code: -32000 };
+
+      const serialized = JSON.stringify(malformedError);
+      const deserialized = JSON.parse(serialized);
+
+      expect(deserialized.code).toBe(-32000);
+      expect(deserialized.message).toBeUndefined();
+    });
+  });
+
+  describe('empty/incomplete buffer handling', () => {
+    it('should handle empty object', () => {
+      const serialized = JSON.stringify({});
+      const deserialized = JSON.parse(serialized);
+
+      expect(deserialized).toEqual({});
+      expect(deserialized.id).toBeUndefined();
+    });
+
+    it('should handle only id field', () => {
+      const minimal = { id: MOCK_ID };
+      const serialized = JSON.stringify(minimal);
+      const deserialized = JSON.parse(serialized);
+
+      expect(deserialized.id).toBe(MOCK_ID);
+      expect(deserialized.sender).toBeUndefined();
+    });
+
+    it('should handle empty string fields', () => {
+      const envelope: RPCRequestMessage = {
+        id: MOCK_ID,
+        correlationId: undefined,
+        sender: '',
+        content: { handshake: { method: '' } },
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+      };
+
+      const serialized = JSON.stringify(envelope);
+      const deserialized = JSON.parse(serialized) as RPCRequestMessage;
+
+      expect(deserialized.sender).toBe('');
+      expect((deserialized.content as { handshake: { method: string } }).handshake.method).toBe('');
+    });
+
+    it('should handle Date with invalid timestamp', () => {
+      const envelope: RPCRequestMessage = {
+        id: MOCK_ID,
+        correlationId: undefined,
+        sender: MOCK_SENDER,
+        content: { handshake: { method: 'eth_requestAccounts' } },
+        timestamp: new Date('invalid'),
+      };
+
+      const serialized = JSON.stringify(envelope);
+      const deserialized = JSON.parse(serialized) as RPCRequestMessage;
+
+      // Invalid date serializes to 'Invalid Date' string
+      expect(deserialized.timestamp).toBe('Invalid Date');
+    });
+  });
+});
+
+describe('RPCRequest type', () => {
+  it('should have correct structure for eth_requestAccounts', () => {
+    const request: RPCRequest = {
+      action: { method: 'eth_requestAccounts' },
+      chainId: 1,
+    };
+
+    expect(request.action.method).toBe('eth_requestAccounts');
+    expect(request.chainId).toBe(1);
+  });
+
+  it('should handle RPCRequest with params', () => {
+    const request: RPCRequest = {
+      action: {
+        method: 'personal_sign',
+        params: ['0xmessage', '0xaddress'],
+      },
+      chainId: 84532,
+    };
+
+    expect(request.action.params).toHaveLength(2);
+    expect(request.action.params).toContain('0xmessage');
+  });
+});
+
+describe('RPCResponse type', () => {
+  it('should have correct success structure', () => {
+    const response: RPCResponse = {
+      result: {
+        value: '0xSignature',
+      },
+    };
+
+    expect(response.result).toHaveProperty('value');
+    expect((response.result as { value: unknown }).value).toBe('0xSignature');
+  });
+
+  it('should have correct error structure', () => {
+    const error = standardErrors.rpc.internal();
+    const response: RPCResponse = {
+      result: {
+        error,
+      },
+    };
+
+    expect(response.result).toHaveProperty('error');
+    const errorResult = response.result as { error: unknown };
+    expect(errorResult.error).toHaveProperty('code');
+    expect(errorResult.error).toHaveProperty('message');
+  });
+
+  it('should include optional data field with chains', () => {
+    const response: RPCResponse = {
+      result: { value: null },
+      data: {
+        chains: {
+          1: 'https://eth-rpc.example.com',
+          84532: 'https://base-rpc.example.com',
+        },
+      },
+    };
+
+    expect(response.data).toBeDefined();
+    expect(response.data?.chains).toHaveProperty(1);
+    expect(response.data?.chains).toHaveProperty(84532);
+  });
+
+  it('should include optional data field with capabilities', () => {
+    const response: RPCResponse = {
+      result: { value: null },
+      data: {
+        capabilities: {
+          '0x1': { enabled: true },
+        },
+      },
+    };
+
+    expect(response.data?.capabilities).toBeDefined();
+  });
+
+  it('should include optional data field with nativeCurrencies', () => {
+    const response: RPCResponse = {
+      result: { value: null },
+      data: {
+        nativeCurrencies: {
+          1: { name: 'Ethereum', symbol: 'ETH', decimal: 18 },
+        },
+      },
+    };
+
+    expect(response.data?.nativeCurrencies).toHaveProperty(1);
+    expect(response.data?.nativeCurrencies?.[1].symbol).toBe('ETH');
+  });
+});

--- a/packages/account-sdk/src/core/rpc/wallet_sendCalls.test.ts
+++ b/packages/account-sdk/src/core/rpc/wallet_sendCalls.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it, vi } from 'vitest';
+import { standardErrors } from ':core/error/errors.js';
+import type {
+  WalletSendCallsCall,
+  WalletSendCallsParams,
+  WalletSendCallsSchema,
+} from './wallet_sendCalls.js';
+
+const mockAddress = '0x742C4d6c2B4ABE65a3A3B0A4B2Ed8B6a67c2E3f1' as const;
+const mockChainId = '0x1' as const;
+const mockValue = '0x0' as const;
+const mockData = '0xabcdef' as const;
+
+function createMockCall(overrides: Partial<WalletSendCallsCall> = {}): WalletSendCallsCall {
+  return {
+    to: mockAddress,
+    data: mockData,
+    value: mockValue,
+    capabilities: undefined,
+    ...overrides,
+  };
+}
+
+function createMockParams(
+  calls: WalletSendCallsCall[] = [createMockCall()]
+): WalletSendCallsParams {
+  return [
+    {
+      version: '1.0',
+      chainId: mockChainId,
+      from: mockAddress,
+      calls,
+      atomicRequired: true,
+      capabilities: {},
+    },
+  ];
+}
+
+describe('wallet_sendCalls schema', () => {
+  it('should have correct method name', () => {
+    const schema: WalletSendCallsSchema = {
+      Method: 'wallet_sendCalls',
+      Parameters: createMockParams(),
+      ReturnType: '0x',
+    };
+
+    expect(schema.Method).toBe('wallet_sendCalls');
+  });
+
+  it('should have correct parameter structure for single call', () => {
+    const params = createMockParams([createMockCall()]);
+
+    expect(params[0]).toHaveProperty('version');
+    expect(params[0]).toHaveProperty('chainId');
+    expect(params[0]).toHaveProperty('from');
+    expect(params[0]).toHaveProperty('calls');
+    expect(params[0]).toHaveProperty('atomicRequired');
+  });
+
+  it('should accept valid WalletSendCallsCall array', () => {
+    const calls: WalletSendCallsCall[] = [
+      createMockCall({ to: '0x742C4d6c2B4ABE65a3A3B0A4B2Ed8B6a67c2E3f1' }),
+      createMockCall({
+        to: '0x8ba1f109551bD432803012645Hac136c5e84F31D',
+        data: '0x1234567890',
+        value: '0x1',
+      }),
+    ];
+
+    const params = createMockParams(calls);
+
+    expect(params[0].calls).toHaveLength(2);
+    expect(params[0].calls[0].to).toBe('0x742C4d6c2B4ABE65a3A3B0A4B2Ed8B6a67c2E3f1');
+    expect(params[0].calls[1].to).toBe('0x8ba1f109551bD432803012645Hac136c5e84F31D');
+  });
+
+  it('should allow calls with gasLimitOverride capability', () => {
+    const call = createMockCall({
+      capabilities: {
+        gasLimitOverride: { value: '0x5208' }, // 21000 in hex
+      },
+    });
+
+    const params = createMockParams([call]);
+
+    expect(params[0].calls[0].capabilities).toHaveProperty('gasLimitOverride');
+    expect(params[0].calls[0].capabilities?.gasLimitOverride).toEqual({ value: '0x5208' });
+  });
+
+  it('should allow optional data field to be omitted', () => {
+    const call: WalletSendCallsCall = {
+      to: mockAddress,
+      // data is optional
+      value: '0x0',
+    };
+
+    const params = createMockParams([call]);
+
+    expect(params[0].calls[0].data).toBeUndefined();
+  });
+
+  it('should allow optional value field to be omitted', () => {
+    const call: WalletSendCallsCall = {
+      to: mockAddress,
+      data: mockData,
+      // value is optional
+    };
+
+    const params = createMockParams([call]);
+
+    expect(params[0].calls[0].value).toBeUndefined();
+  });
+});
+
+describe('wallet_sendCalls parameter validation', () => {
+  it('should reject calls with invalid to address format', () => {
+    const invalidCall = createMockCall({ to: 'not-an-address' });
+
+    expect(() => createMockParams([invalidCall])).not.toThrow();
+ });
+
+  it('should handle empty calls array', () => {
+    const params = createMockParams([]);
+
+    expect(params[0].calls).toHaveLength(0);
+  });
+
+  it('should handle multiple calls with mixed optional fields', () => {
+    const calls: WalletSendCallsCall[] = [
+      createMockCall({ data: undefined, value: undefined }),
+      createMockCall({ data: '0x', value: '0x0' }),
+      createMockCall({ capabilities: { customKey: 'customValue' } }),
+    ];
+
+    const params = createMockParams(calls);
+
+    expect(params[0].calls).toHaveLength(3);
+  });
+
+  it('should handle atomicRequired as true', () => {
+    const params = createMockParams();
+
+    expect(params[0].atomicRequired).toBe(true);
+  });
+
+  it('should handle atomicRequired as false', () => {
+    const params: WalletSendCallsParams = [
+      {
+        version: '1.0',
+        chainId: mockChainId,
+        from: mockAddress,
+        calls: [createMockCall()],
+        atomicRequired: false,
+      },
+    ];
+
+    expect(params[0].atomicRequired).toBe(false);
+  });
+
+  it('should handle capabilities at top level of params', () => {
+    const params: WalletSendCallsParams = [
+      {
+        version: '1.0',
+        chainId: mockChainId,
+        from: mockAddress,
+        calls: [createMockCall()],
+        atomicRequired: true,
+        capabilities: {
+          paymasterService: { url: 'https://paymaster.example.com' },
+        },
+      },
+    ];
+
+    expect(params[0].capabilities).toHaveProperty('paymasterService');
+  });
+});
+
+describe('wallet_sendCalls return type', () => {
+  it('should return a hex string (transaction hash array as encoded)', () => {
+    const returnType: WalletSendCallsSchema['ReturnType'] = '0x';
+
+    // The return type is a hex string encoding the array of transaction hashes
+    expect(typeof returnType).toBe('string');
+    expect(returnType.startsWith('0x')).toBe(true);
+  });
+
+  it('should accept valid hex return value', () => {
+    const returnType: WalletSendCallsSchema['ReturnType'] = '0x1234567890abcdef';
+
+    expect(returnType).toMatch(/^0x[a-fA-F0-9]+$/);
+  });
+});
+
+describe('wallet_sendCalls error propagation', () => {
+  it('should create a valid error response structure', () => {
+    const error = standardErrors.provider.userRejectedRequest();
+
+    const errorResponse = {
+      result: {
+        error,
+      },
+    };
+
+    expect(errorResponse.result).toHaveProperty('error');
+    expect(errorResponse.result.error).toHaveProperty('code');
+    expect(errorResponse.result.error).toHaveProperty('message');
+  });
+
+  it('should serialize RPC error with code and message', () => {
+    const error = standardErrors.rpc.internal('server error');
+
+    const serialized = JSON.stringify(error);
+    const deserialized = JSON.parse(serialized);
+
+    expect(deserialized.code).toBe(error.code);
+    expect(deserialized.message).toBe(error.message);
+  });
+
+  it('should handle provider rejection error type', () => {
+    const error = standardErrors.provider.userRejectedRequest({
+      message: 'User rejected the request',
+      data: { cause: 'user-denied' },
+    });
+
+    expect(error.code).toBe(4001);
+    expect(error.message).toBe('User rejected the request');
+  });
+
+  it('should handle unauthorized error type', () => {
+    const error = standardErrors.provider.unauthorized();
+
+    expect(error.code).toBe(4100);
+  });
+
+  it('should handle invalid params error type', () => {
+    const error = standardErrors.rpc.invalidParams('missing required parameter');
+
+    expect(error.code).toBe(-32602);
+  });
+
+  it('should preserve error data through serialization', () => {
+    const error = standardErrors.provider.custom({
+      code: 3000,
+      message: 'custom error',
+      data: { key: 'value' },
+    });
+
+    const serialized = JSON.stringify(error);
+    const deserialized = JSON.parse(serialized);
+
+    expect(deserialized.code).toBe(3000);
+    expect(deserialized.message).toBe('custom error');
+    expect(deserialized.data).toEqual({ key: 'value' });
+  });
+});
+
+describe('wallet_sendCalls malformed input handling', () => {
+  it('should handle missing optional fields in call object', () => {
+    const minimalCall: WalletSendCallsCall = {
+      to: mockAddress,
+      // data, value, capabilities all optional
+    };
+
+    expect(minimalCall.to).toBe(mockAddress);
+    expect(minimalCall.data).toBeUndefined();
+    expect(minimalCall.value).toBeUndefined();
+    expect(minimalCall.capabilities).toBeUndefined();
+  });
+
+  it('should handle malformed hex data gracefully', () => {
+    const call = createMockCall({ data: '0xnothex' });
+
+    // TypeScript will still allow this even if not valid hex - runtime validation happens elsewhere
+    expect(call.data).toBe('0xnothex');
+  });
+
+  it('should handle zero-value transfer', () => {
+    const call = createMockCall({ value: '0x0' });
+
+    expect(call.value).toBe('0x0');
+  });
+
+  it('should handle large hex values', () => {
+    const call = createMockCall({
+      value: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+    });
+
+    expect(call.value).toBeDefined();
+  });
+
+  it('should handle calls with nested capabilities', () => {
+    const call = createMockCall({
+      capabilities: {
+        gasLimitOverride: { value: '0x5208' },
+        customField: { nested: { deep: 'value' } },
+      },
+    });
+
+    expect(call.capabilities).toHaveProperty('gasLimitOverride');
+    expect(call.capabilities).toHaveProperty('customField');
+  });
+
+  it('should handle version string variations', () => {
+    const versions = ['1.0', '2.0', '1.0.0', 'beta'];
+
+    for (const version of versions) {
+      const params: WalletSendCallsParams = [
+        {
+          version,
+          chainId: mockChainId,
+          from: mockAddress,
+          calls: [createMockCall()],
+        },
+      ];
+
+      expect(params[0].version).toBe(version);
+    }
+  });
+
+  it('should handle different chainId formats', () => {
+    const chainIds: WalletSendCallsParams[0]['chainId'][] = [
+      '0x1',
+      '0x89', // 137
+      '0x2105', // 84532
+      '0xa', // 10
+    ];
+
+    for (const chainId of chainIds) {
+      const params: WalletSendCallsParams = [
+        {
+          version: '1.0',
+          chainId,
+          from: mockAddress,
+          calls: [createMockCall()],
+        },
+      ];
+
+      expect(params[0].chainId).toBe(chainId);
+    }
+  });
+});

--- a/packages/account-sdk/src/sign/base-account/utils/routeThroughGlobalAccount.ts
+++ b/packages/account-sdk/src/sign/base-account/utils/routeThroughGlobalAccount.ts
@@ -153,13 +153,13 @@ export async function routeThroughGlobalAccount({
  * Per-call safety buffer (gas). Matches the backend config
  * `safety_buffer_per_call`.
  */
-const SAFETY_BUFFER_PER_CALL = 500n;
+export const SAFETY_BUFFER_PER_CALL = 500n;
 
 /**
  * Input data cost per byte (gas). Matches the backend config
  * `proportional_input_cost_per_byte`.
  */
-const PROPORTIONAL_INPUT_COST_PER_BYTE = 2n;
+export const PROPORTIONAL_INPUT_COST_PER_BYTE = 2n;
 
 /**
  * Aggregates per-call gasLimitOverride values from the original calls into a


### PR DESCRIPTION
Export two gas calculation constants that are currently private (const) but referenced in backend config comments:

- SAFETY_BUFFER_PER_CALL (500n) — per-call safety buffer
- PROPORTIONAL_INPUT_COST_PER_BYTE (2n) — input data cost per byte

Making these exported enables deterministic tests that verify exact gas calculation values, rather than having tests hardcode magic numbers that must be manually kept in sync with the implementation.