### PR TITLE
docs: fix grammar typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ console.log(`Payment status: ${status.status}`);
 
 ## Base Subscriptions - Quick Start
 
-**Base Subscriptions lets you create recurring USDC payments**
+**Base Subscriptions let you create recurring USDC payments**
 
 ### Create a Subscription
 


### PR DESCRIPTION
This PR fixes a minor grammar typo in `README.md` (`Base Subscriptions lets` -> `Base Subscriptions let`).