### PR TITLE
docs(prepareSpendCallData): replace Promise.all with sequential awaits in eth_sendTransaction example

### DIFF
--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareSpendCallData.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/prepareSpendCallData.ts
@@ -90,18 +90,21 @@ export type PrepareSpendCallDataResponseType = Call[];
  *   }],
  * });
  *
- * // Or send the calls using eth_sendTransaction to submit both calls in exact order
- * const promises = spendCalls.map((call) => provider.request({
- *   method: 'eth_sendTransaction',
- *   params: [
- *     {
- *       ...call,
- *       from: permission.permission.spender, // Must be the spender!
- *     }
- *   ]
- * }))
- *
- * await Promise.all(promises);
+ * // Or send the calls using eth_sendTransaction — note: calls must be submitted
+ * // sequentially and awaited one at a time. Using Promise.all here would submit
+ * // both concurrently and risk the spend call landing before approveWithSignature
+ * // is confirmed, causing a revert. wallet_sendCalls with atomicRequired is safer.
+ * for (const call of spendCalls) {
+ *   await provider.request({
+ *     method: 'eth_sendTransaction',
+ *     params: [
+ *       {
+ *         ...call,
+ *         from: permission.permission.spender, // Must be the spender!
+ *       }
+ *     ]
+ *   });
+ * }
  * ```
  */
 // ERC20 transfer function ABI for recipient transfers


### PR DESCRIPTION
The `eth_sendTransaction` example in the `prepareSpendCallData` JSDoc used `Promise.all` to submit the calls, but the comment claimed they would execute "in exact order":

```typescript
// Or send the calls using eth_sendTransaction to submit both calls in exact order
const promises = spendCalls.map((call) => provider.request({ ... }))
await Promise.all(promises);
```

`Promise.all` submits all requests concurrently there is no guarantee that `approveWithSignature` confirms before `spend` is mined. For a not-yet-approved permission, both transactions can land in the same block, causing `spend` to revert because the permission isn't approved yet.

This PR replaces the example with a sequential `for...of` loop that awaits each call before submitting the next, and adds a comment explaining why `Promise.all` is unsafe here and why `wallet_sendCalls` with `atomicRequired: true` is the recommended path.

No code changes JSDoc comment only.