### PR TITLE
fix(signer): sanitize chain state on reconnect to prevent stale address

### DIFF
--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -94,7 +94,7 @@ export class Signer {
 
     const { account, chains } = this.storeInstance.getState();
     this.accounts = account.accounts ?? [];
-    this.chain = account.chain ?? {
+    this.chain = account.chain ?? chains?.[0] ?? {
       id: params.metadata.appChainIds?.[0] ?? 1,
     };
 
@@ -433,7 +433,8 @@ export class Signer {
 
     // reset the signer
     this.accounts = [];
-    this.chain = {
+    const chains = this.storeInstance.getState().chains;
+    this.chain = chains?.[0] ?? {
       id: metadata?.appChainIds?.[0] ?? 1,
     };
   }


### PR DESCRIPTION
## Summary

Fixes #214 — incorrect or missing public address after reconnecting signer.

### Root Cause

When `Signer` is reconstructed after `cleanup()` (e.g., page reload + reconnect):
1. The constructor reads `account.chain` from the store.
2. If the store was cleared by `cleanup()`, `account.chain` is `undefined`.
3. The fallback `params.metadata.appChainIds?.[0] ?? 1` could be stale, missing, or default to chain id 1 (Ethereum mainnet) even when the user was on Base (8453).
4. This caused `this.accounts` to remain empty until the next handshake, and `handleGetCapabilitiesRequest` to throw `unauthorized`.

### Fix

Prefer the `chains` array already registered in the store before falling back to constructor metadata:

**Constructor:**
```ts
this.chain = account.chain ?? chains?.[0] ?? {
  id: params.metadata.appChainIds?.[0] ?? 1,
};
```

**cleanup():**
```ts
const chains = this.storeInstance.getState().chains;
this.chain = chains?.[0] ?? {
  id: metadata?.appChainIds?.[0] ?? 1,
};
```

This ensures the correct chain context (e.g., Base mainnet 8453) is preserved across reconnect cycles instead of silently falling back to Ethereum mainnet.

### Test Plan
- `yarn workspace @base-org/account test --run` → 999/999 pass

## Related Issues
- Closes #214
