### PR TITLE
fix: throw instead of return in sendRequestToSubAccountSigner and harden spend-permission production guard

### DIFF
--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/utils.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/utils.ts
@@ -124,9 +124,8 @@ export function createSpendPermissionTypedDataWithSeconds(
 
   // Runtime check to prevent misuse
   if (process.env.NODE_ENV === 'production') {
-    console.warn(
-      '⚠️ createSpendPermissionTypedDataWithSeconds is being used. ' +
-        'This function is intended for testing purposes only.'
+    throw new Error(
+      'createSpendPermissionTypedDataWithSeconds is for testing only and must not be called in production.'
     );
   }
 

--- a/packages/account-sdk/src/sign/base-account/Signer.ts
+++ b/packages/account-sdk/src/sign/base-account/Signer.ts
@@ -792,7 +792,7 @@ export class Signer {
           correlationId,
           errorMessage: parseErrorMessageFromAny(error),
         });
-        return standardErrors.provider.unauthorized(
+        throw standardErrors.provider.unauthorized(
           'failed to add sub account owner when sending request to sub account signer'
         );
       }


### PR DESCRIPTION
Fixes #326. Fixes #325.

## Changes

### 1. sendRequestToSubAccountSigner: return → throw (#326)

`Signer.ts:795` used `return standardErrors.provider.unauthorized()` inside a catch block. Since `standardErrors.provider.unauthorized()` is a factory that returns an `EthereumProviderError` object, the async function's Promise resolved successfully with the error object as its value instead of rejecting. The caller's catch block never fired, so the error was silently swallowed and returned to the dApp as if it were a valid RPC result.

Changed to `throw` so the Promise rejects and the caller handles the error correctly.

### 2. createSpendPermissionTypedDataWithSeconds: console.warn → throw (#325)

The production guard in `utils.ts:126` used `console.warn`, which is invisible in production logging pipelines and does not prevent the function from returning valid typed data. A developer who accidentally ships a call to this test-only function in production receives a fully-formed `SpendPermissionTypedData` that can be signed and submitted on-chain.

Changed to `throw new Error()` so production callers fail fast and loudly.