### PR TITLE
fix: reject malformed amount strings in validateStringAmount

### DIFF
--- a/packages/account-sdk/src/interface/payment/utils/validation.test.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.test.ts
@@ -20,6 +20,14 @@ describe('validateStringAmount', () => {
     );
   });
 
+  it('rejects malformed numeric strings that parseFloat would accept', () => {
+    const message = 'Invalid amount: must be a valid number';
+    const malformed = ['1abc', '1.2.3', '1foo', '1e6', '1.', '.', ''];
+    for (const value of malformed) {
+      expect(() => validateStringAmount(value, 6)).toThrow(message);
+    }
+  });
+
   it('should reject non-string amounts', () => {
     expect(() => validateStringAmount(10 as any, 6)).toThrow('Invalid amount: must be a string');
   });

--- a/packages/account-sdk/src/interface/payment/utils/validation.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.ts
@@ -11,13 +11,14 @@ export function validateStringAmount(amount: string, maxDecimals: number): void 
     throw new Error('Invalid amount: must be a string');
   }
 
-  const numAmount = parseFloat(amount);
-
-  if (isNaN(numAmount)) {
+  // parseFloat is too lenient: it reads a leading numeric prefix and accepts values
+  // like "1abc", "1.2.3" or "1e6", which then fail later in parseUnits. Require a
+  // plain decimal string instead.
+  if (!/^-?\d+(\.\d+)?$/.test(amount)) {
     throw new Error('Invalid amount: must be a valid number');
   }
 
-  if (numAmount <= 0) {
+  if (Number(amount) <= 0) {
     throw new Error('Invalid amount: must be greater than 0');
   }
 


### PR DESCRIPTION
validateStringAmount used parseFloat to check the amount. parseFloat reads a leading numeric prefix and ignores the rest, so "1abc" becomes 1, "1.2.3" becomes 1.2 and "1e6" becomes 1000000. Those pass validation and only fail later in parseUnits, which expects a plain decimal string. A commenter on the issue also flagged the "1e6" scientific notation case.

Replaced the parseFloat check with a strict decimal regex. The rest of the behavior is unchanged on purpose: negative and zero amounts still throw "must be greater than 0", non string input still throws "must be a string", and the max decimal places check is untouched. All existing tests still pass.

Added a test that runs the malformed inputs through the validator and checks they are rejected.

Closes #313
