### PR TITLE
fix: use wallet-substituted account in returned spend permission

### DIFF
--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/requestSpendPermission.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/requestSpendPermission.test.ts
@@ -327,6 +327,45 @@ describe('requestSpendPermission', () => {
       });
     });
 
+    it('returns the wallet-substituted account from signedData, not the original', async () => {
+      const capabilities: WalletSignCapabilities = {
+        spendPermission: {
+          requireBalance: true,
+        },
+      };
+
+      // Wallet substitutes message.account via mutableData (e.g. EOA to smart wallet)
+      const substitutedAccount = '0xabcdef0123456789abcdef0123456789abcdef01' as `0x${string}`;
+      const substitutedTypedData: SpendPermissionTypedData = {
+        ...mockTypedData,
+        message: {
+          ...mockTypedData.message,
+          account: substitutedAccount,
+        },
+      };
+
+      (createSpendPermissionTypedData as Mock).mockReturnValue(mockTypedData);
+      (mockProviderRequest as Mock).mockResolvedValue({
+        signature: mockSignature,
+        signedData: substitutedTypedData,
+      });
+      (getHash as Mock).mockResolvedValue(mockPermissionHash);
+
+      const result = await requestSpendPermission({
+        ...mockRequestData,
+        capabilities,
+      });
+
+      // permissionHash is derived from the substituted message
+      expect(getHash).toHaveBeenCalledWith({
+        permission: substitutedTypedData.message,
+        chainId: mockRequestData.chainId,
+      });
+      // the returned permission reflects the substituted account, not the original
+      expect(result.permission).toEqual(substitutedTypedData.message);
+      expect(result.permission).not.toEqual(mockTypedData.message);
+    });
+
     it('should handle invalid wallet_sign response', async () => {
       const capabilities: WalletSignCapabilities = {
         spendPermission: {

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/requestSpendPermission.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/methods/requestSpendPermission.ts
@@ -78,6 +78,7 @@ const requestSpendPermissionFn = async (
   // Check if we should use wallet_sign (when capabilities are provided) or eth_signTypedData_v4
   let signature: string;
   let permissionHash: string;
+  let permissionMessage: typeof typedData.message;
 
   if (capabilities) {
     // Use wallet_sign with capabilities
@@ -122,6 +123,9 @@ const requestSpendPermissionFn = async (
     };
 
     signature = signResult.signature;
+    // Use the wallet-returned (post-substitution) message: mutableData allows the
+    // wallet to replace message.account, and permissionHash below is computed from it.
+    permissionMessage = signResult.signedData.message;
     permissionHash = await getHash({
       permission: signResult.signedData.message,
       chainId,
@@ -135,6 +139,7 @@ const requestSpendPermissionFn = async (
       }) as Promise<string>,
       getHash({ permission: typedData.message, chainId }),
     ]);
+    permissionMessage = typedData.message;
   }
 
   const permission: SpendPermission = {
@@ -142,7 +147,7 @@ const requestSpendPermissionFn = async (
     permissionHash,
     signature,
     chainId,
-    permission: typedData.message,
+    permission: permissionMessage,
   };
 
   return permission;


### PR DESCRIPTION
requestSpendPermission sends `mutableData: { fields: ['message.account'] }` so the wallet may replace the account (for example swapping an EOA for a smart wallet). It computes `permissionHash` from the wallet-returned `signedData.message`, but built the returned `SpendPermission.permission` from the original `typedData.message`.

When the wallet actually substitutes the account the two disagree: `permissionHash` is over the new account while `permission.account` still holds the original. Anything downstream that reads `result.permission.account` (display, storage, prepareSpendCallData, fetchPermissions) then sees the wrong address.

Carry the signed message through a variable and use it for both the hash and the returned permission. The `eth_signTypedData_v4` branch has no substitution so it is unchanged.

Added a test where `signedData.message.account` differs from the request account and checks the returned permission matches the substituted message, not the original.

Closes #324
