### PR TITLE
fix: pin spend permission spender when routing through global account

### DIFF
--- a/packages/account-sdk/src/sign/base-account/utils/routeThroughGlobalAccount.test.ts
+++ b/packages/account-sdk/src/sign/base-account/utils/routeThroughGlobalAccount.test.ts
@@ -210,6 +210,43 @@ describe('routeThroughGlobalAccount', () => {
       );
     });
 
+    it('should strip request spendPermissions before injecting the sub account spender', async () => {
+      const attackerAddress = '0x1111111111111111111111111111111111111111';
+      const paymasterService = { url: 'https://paymaster.example.com' };
+
+      // @ts-ignore - testing with mock args
+      args.request.params[0].capabilities = {
+        paymasterService,
+        spendPermissions: {
+          request: {
+            spender: attackerAddress,
+          },
+        },
+      };
+      mockGlobalAccountRequest.mockResolvedValue('0x1234ca11');
+
+      await routeThroughGlobalAccount(args);
+
+      expect(injectRequestCapabilities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: [
+            expect.objectContaining({
+              capabilities: {
+                paymasterService,
+              },
+            }),
+          ],
+        }),
+        {
+          spendPermissions: {
+            request: {
+              spender: subAccountAddress,
+            },
+          },
+        }
+      );
+    });
+
     it('should store returned spend permissions in cache', async () => {
       const mockSpendPermissions = [
         {

--- a/packages/account-sdk/src/sign/base-account/utils/routeThroughGlobalAccount.ts
+++ b/packages/account-sdk/src/sign/base-account/utils/routeThroughGlobalAccount.ts
@@ -107,12 +107,19 @@ export async function routeThroughGlobalAccount({
     batchCall,
   ];
 
+  const { capabilities: originalCapabilities, ...safeSendCallsParams } = originalSendCallsParams;
+  const safeCapabilities = { ...(originalCapabilities ?? {}) };
+  // The dApp controls the original request, so never let it override the SDK-pinned spender.
+  delete safeCapabilities.spendPermissions;
+  const hasSafeCapabilities = Object.keys(safeCapabilities).length > 0;
+
   const requestToParent = injectRequestCapabilities(
     {
       method: 'wallet_sendCalls',
       params: [
         {
-          ...originalSendCallsParams,
+          ...safeSendCallsParams,
+          ...(hasSafeCapabilities ? { capabilities: safeCapabilities } : {}),
           calls,
           from: globalAccountAddress,
           version: '2.0.0',


### PR DESCRIPTION
## Summary
- Strip dApp-supplied `spendPermissions` before routing sendCalls through the global account.
- Preserve unrelated request capabilities and inject the SDK-pinned sub-account spender.
- Add a regression test for attacker-supplied spend permission spender override.

## Test plan
- `yarn workspace @base-org/account test --run src/sign/base-account/utils/routeThroughGlobalAccount.test.ts`
- Cursor lints on touched files


Made with [Cursor](https://cursor.com)