### PR TITLE
fix: correct code examples in Base Account SDK and payment READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ yarn add @base-org/account
 3. Request accounts to initialize a connection to wallet
 
    ```js
-   const addresses = provider.request({
+   const addresses = await provider.request({
      method: 'eth_requestAccounts',
    });
    ```
@@ -181,10 +181,13 @@ yarn add @base-org/account
 4. Make more requests
 
    ```js
-   provider.request('personal_sign', [
-     `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
-     addresses[0],
-   ]);
+   provider.request({
+     method: 'personal_sign',
+     params: [
+       `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
+       addresses[0],
+     ],
+   });
    ```
 
 5. Handle provider events

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ yarn add @base-org/account
 3. Request accounts to initialize a connection to wallet
 
    ```js
-   const addresses = provider.request({
+   const addresses = await provider.request({
      method: 'eth_requestAccounts',
    });
    ```
@@ -210,10 +210,13 @@ yarn add @base-org/account
 4. Make more requests
 
    ```js
-   provider.request('personal_sign', [
-     `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
-     addresses[0],
-   ]);
+   provider.request({
+     method: 'personal_sign',
+     params: [
+       `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
+       addresses[0],
+     ],
+   });
    ```
 
 5. Handle provider events

--- a/packages/account-sdk/README.md
+++ b/packages/account-sdk/README.md
@@ -78,7 +78,7 @@
 3. Request accounts to initialize a connection to wallet
 
    ```js
-   const addresses = provider.request({
+   const addresses = await provider.request({
      method: 'eth_requestAccounts',
    });
    ```
@@ -86,10 +86,13 @@
 4. Make more requests
 
    ```js
-   provider.request('personal_sign', [
-     `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
-     addresses[0],
-   ]);
+   provider.request({
+     method: 'personal_sign',
+     params: [
+       `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
+       addresses[0],
+     ],
+   });
    ```
 
 5. Handle provider events
@@ -127,7 +130,7 @@
 
 ## Script Tag Usage
 
-Base Accunt can be used directly in HTML pages via a script tag, without any build tools:
+Base Account can be used directly in HTML pages via a script tag, without any build tools:
 
 ```html
 <!-- Via unpkg -->

--- a/packages/account-sdk/src/interface/payment/README.md
+++ b/packages/account-sdk/src/interface/payment/README.md
@@ -8,6 +8,7 @@ The payment interface provides a simple way to make USDC payments on Base networ
 import { pay } from '@base-org/account';
 
 // Basic payment
+// pay() resolves on success and throws on failure
 const payment = await pay({
   amount: "10.50",
   to: "0xFe21034794A5a574B94fE4fDfD16e005F1C96e51",
@@ -15,11 +16,7 @@ const payment = await pay({
   testnet: true
 });
 
-if (payment.success) {
-  console.log(`Payment sent! Transaction ID: ${payment.id}`);
-} else {
-  console.error(`Payment failed: ${payment.error}`);
-}
+console.log(`Payment sent! Transaction ID: ${payment.id}`);
 ```
 
 ## Checking Payment Status
@@ -27,7 +24,7 @@ if (payment.success) {
 You can check the status of a payment using the transaction ID returned from the pay function:
 
 ```typescript
-import { getPaymentStatus } from '@base/account-sdk';
+import { getPaymentStatus } from '@base-org/account';
 
 // Check payment status
 const status = await getPaymentStatus({
@@ -43,7 +40,7 @@ switch (status.status) {
     console.log(`Payment completed! Amount: ${status.amount} to ${status.recipient}`);
     break;
   case 'failed':
-    console.log(`Payment failed: ${status.error}`);
+    console.log(`Payment failed: ${status.reason}`);
     break;
   case 'not_found':
     console.log('Payment not found');
@@ -160,4 +157,4 @@ The payment result is always a successful payment (errors are thrown as exceptio
 - `sender?: string` - Sender address (present for pending, completed, and failed)
 - `amount?: string` - Amount sent (present for completed transactions, parsed from logs)
 - `recipient?: string` - Recipient address (present for completed transactions, parsed from logs)
-- `error?: string` - Error message (present for failed status - includes both on-chain failure reasons and off-chain errors) 
+- `reason?: string` - Reason for transaction failure (present for failed status - describes why the transaction failed on-chain) 


### PR DESCRIPTION
## What

Fixes several code examples in the README files that don't match the actual SDK API and would fail if copy-pasted.

## Changes

1. **`provider.request()` signature** (`README.md`, `packages/account-sdk/README.md`) — the "Basic Usage" example called `provider.request('personal_sign', [...])` with positional arguments. The method signature is `request(args: RequestArguments): Promise<unknown>` and the runtime validation (`checkErrorForInvalidRequestArgs`) throws `Expected a single, non-array, object argument.` for anything that isn't a single object. Changed to `provider.request({ method: 'personal_sign', params: [...] })`, matching the `eth_requestAccounts` example just above it.

2. **Missing `await`** (both READMEs) — `const addresses = provider.request({ method: 'eth_requestAccounts' })` returned a Promise, so the next step's `addresses[0]` was indexing a Promise (`undefined`). Added `await`.

3. **Wrong import path** (`packages/account-sdk/src/interface/payment/README.md`) — `import { getPaymentStatus } from '@base/account-sdk'` referenced a non-existent package. Corrected to `@base-org/account` (consistent with the other imports in the same file).

4. **Align payment examples with the real API** — `pay()` resolves on success and throws on failure (`PaymentResult` is `PaymentSuccess` only), so the `if (payment.success) ... else payment.error` branch was dead code referencing a non-existent `payment.error`. Simplified to reflect the throw-on-failure contract. Also `PaymentStatus` exposes `reason`, not `error`, so `status.error` → `status.reason` (and the API Reference entry updated to match).

5. **Typo** — "Base Accunt" → "Base Account".

## Notes

Docs-only change. No code or public API is modified.