### PR TITLE
fix(docs): import ref in Vue README TypeScript example

### DIFF
--- a/packages/account-ui/src/frameworks/vue/README.md
+++ b/packages/account-ui/src/frameworks/vue/README.md
@@ -165,7 +165,7 @@ If you're using TypeScript with Vue, the package includes full type definitions:
 
 <script setup lang="ts">
 import { SignInWithBaseButton } from '@base-org/account-ui/vue';
-import type { Ref } from 'vue';
+import { ref, type Ref } from 'vue';
 
 interface User {
   id: string;


### PR DESCRIPTION
## What

The Vue integration guide's TypeScript example (`packages/account-ui/src/frameworks/vue/README.md`) imports only the `Ref` **type** from `vue`, but then calls the `ref()` function:

```ts
import { SignInWithBaseButton } from '@base-org/account-ui/vue';
import type { Ref } from 'vue';
...
const currentUser: Ref<User | null> = ref(null);   // ref is never imported
```

In a standard Vue 3 `<script setup>`, `ref` is not auto-imported (that only happens with plugins like `unplugin-auto-import` or Nuxt). As written, copy-pasting the snippet fails with `ReferenceError: ref is not defined`.

## Fix

Import the `ref` function alongside the type:

```ts
import { ref, type Ref } from 'vue';
```

Docs-only change; no code or public API is affected.