### PR TITLE
fix(docs): correct example app path in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Then, from the root folder run:
 The SDK is built using yarn workspaces. 
 
 - `packages/account-sdk` - The main package that exports the SDK
-- `examples/test-app` - An example React app that is used to test the SDK in a real browser environment
+- `examples/testapp` - An example React app that is used to test the SDK in a real browser environment
 
 Use `yarn dev` to start the example app and build the package with hot reloading.
 


### PR DESCRIPTION
## What

The "Navigating the codebase" section in `CONTRIBUTING.md` lists the example app as `examples/test-app`:

```
- `examples/test-app` - An example React app that is used to test the SDK in a real browser environment
```

But the directory is actually `examples/testapp` (no hyphen) — consistent with `AGENTS.md` (`examples/testapp -- playground app`) and the `examples/*` yarn workspace glob. The `examples/test-app` path doesn't exist, so anyone following the guide won't find it.

## Fix

`examples/test-app` → `examples/testapp`.

Docs-only change.