### PR TITLE
fix(spend-permission): await wrapped async util in withTelemetry

### DIFF
--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/withTelemetry.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/withTelemetry.test.ts
@@ -1,0 +1,113 @@
+import {
+  logSpendPermissionUtilCompleted,
+  logSpendPermissionUtilError,
+  logSpendPermissionUtilStarted,
+} from ':core/telemetry/events/spend-permission.js';
+import { store } from ':store/store.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { withTelemetry } from './withTelemetry.js';
+
+// Mock telemetry events (house pattern)
+vi.mock(':core/telemetry/events/spend-permission.js', () => ({
+  logSpendPermissionUtilStarted: vi.fn(),
+  logSpendPermissionUtilCompleted: vi.fn(),
+  logSpendPermissionUtilError: vi.fn(),
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('withTelemetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Ensure telemetry is enabled (wrapper active). The flag is read at
+    // withTelemetry(fn) call time, so reset it before each test.
+    store.config.set({ preference: undefined });
+  });
+
+  it('logs Completed only AFTER the wrapped async fn resolves', async () => {
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(() => deferred.promise);
+
+    const wrapped = withTelemetry(fn);
+    const resultPromise = wrapped();
+
+    // Started fired synchronously; Completed must NOT fire until the promise resolves.
+    expect(logSpendPermissionUtilStarted).toHaveBeenCalledTimes(1);
+    expect(logSpendPermissionUtilCompleted).not.toHaveBeenCalled();
+    expect(logSpendPermissionUtilError).not.toHaveBeenCalled();
+
+    deferred.resolve('done');
+    await resultPromise;
+
+    expect(logSpendPermissionUtilCompleted).toHaveBeenCalledTimes(1);
+    expect(logSpendPermissionUtilError).not.toHaveBeenCalled();
+  });
+
+  it('logs Error when the wrapped async fn rejects', async () => {
+    const fetchPermissionFn = async () => {
+      throw new Error('boom');
+    };
+
+    const wrapped = withTelemetry(fetchPermissionFn);
+
+    await expect(wrapped()).rejects.toThrow('boom');
+
+    expect(logSpendPermissionUtilError).toHaveBeenCalledTimes(1);
+    expect(logSpendPermissionUtilError).toHaveBeenCalledWith('fetchPermission', 'boom');
+    expect(logSpendPermissionUtilCompleted).not.toHaveBeenCalled();
+  });
+
+  it('logs Started before completion', async () => {
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(() => deferred.promise);
+
+    const wrapped = withTelemetry(fn);
+    const resultPromise = wrapped();
+
+    expect(logSpendPermissionUtilStarted).toHaveBeenCalledTimes(1);
+
+    deferred.resolve('done');
+    await resultPromise;
+  });
+
+  it('passes through and logs nothing when telemetry is disabled', async () => {
+    store.config.set({ preference: { telemetry: false } });
+
+    const fn = vi.fn(async () => 'value');
+    const wrapped = withTelemetry(fn);
+
+    // Passthrough: the raw fn is returned unchanged.
+    expect(wrapped).toBe(fn);
+
+    await wrapped();
+
+    expect(logSpendPermissionUtilStarted).not.toHaveBeenCalled();
+    expect(logSpendPermissionUtilCompleted).not.toHaveBeenCalled();
+    expect(logSpendPermissionUtilError).not.toHaveBeenCalled();
+  });
+
+  it('propagates the resolved value unchanged', async () => {
+    const fn = async () => 'the-value';
+    const wrapped = withTelemetry(fn);
+
+    await expect(wrapped()).resolves.toBe('the-value');
+  });
+
+  it('derives the function name (strips the Fn suffix)', async () => {
+    const fetchPermissionFn = async () => 'ok';
+    const wrapped = withTelemetry(fetchPermissionFn);
+
+    await wrapped();
+
+    expect(logSpendPermissionUtilStarted).toHaveBeenCalledWith('fetchPermission');
+    expect(logSpendPermissionUtilCompleted).toHaveBeenCalledWith('fetchPermission');
+  });
+});

--- a/packages/account-sdk/src/interface/public-utilities/spend-permission/withTelemetry.ts
+++ b/packages/account-sdk/src/interface/public-utilities/spend-permission/withTelemetry.ts
@@ -15,11 +15,11 @@ export function withTelemetry<T extends (...args: any[]) => any>(fn: T) {
     return fn;
   }
 
-  return (...args: Parameters<T>): ReturnType<T> => {
+  return async (...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> => {
     const functionName = getFunctionName(fn);
     logSpendPermissionUtilStarted(functionName);
     try {
-      const result = fn(...args);
+      const result = await fn(...args);
       logSpendPermissionUtilCompleted(functionName);
       return result;
     } catch (error) {


### PR DESCRIPTION
## Problem
`withTelemetry` (the HOF wrapping the spend-permission utilities) is synchronous and does not
`await` the wrapped call. Because all 8 wrapped utilities are async, the completed telemetry
event fires on promise creation (wrong timing) and async rejections bypass the sync try/catch,
so error telemetry is never logged.

## Change
Make the returned wrapper `async` and `await` the call inside the existing try/catch, mirroring
the repo's correct sibling HOFs (`withMeasurement`, `withSignerMeasurement`). The
`telemetry === false` passthrough is preserved. Public behavior is unchanged (the returned
promise resolves/rejects identically); only internal telemetry timing and error capture are fixed.

## Testing
Added first-ever coverage in `withTelemetry.test.ts` (6 tests), written test-first:
- completed event fires only AFTER the wrapped async fn resolves (failed before the fix)
- error event is logged on async rejection (failed before the fix)
- started fires before completion (regression guard)
- `telemetry === false` passthrough returns the raw fn and logs nothing
- resolved value propagates unchanged
- function name derivation

- `yarn test --run`: full suite green (account package 74 files / 1006 tests; the 8 wrapped
  utilities' existing tests still pass)
- `yarn format`: clean (Biome)
- `yarn build:packages`: type-checks

Closes #361
