### PR TITLE
fix: propagate pending user operation RPC errors

### DIFF
--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
@@ -168,6 +168,40 @@ describe('getPaymentStatus', () => {
     });
   });
 
+  it('should propagate RPC errors from the pending user operation lookup', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        json: async () => ({ jsonrpc: '2.0', id: 1, result: null }),
+      } as Response)
+      .mockResolvedValueOnce({
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: 2,
+          error: {
+            code: -32602,
+            message: 'Invalid user operation hash',
+          },
+        }),
+      } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xinvalid',
+        testnet: false,
+      })
+    ).rejects.toThrow('RPC error: Invalid user operation hash');
+
+    const { logPaymentStatusCheckCompleted, logPaymentStatusCheckError } = await import(
+      ':core/telemetry/events/payment.js'
+    );
+    expect(logPaymentStatusCheckCompleted).not.toHaveBeenCalled();
+    expect(logPaymentStatusCheckError).toHaveBeenCalledWith({
+      testnet: false,
+      correlationId: 'mock-correlation-id',
+      errorMessage: 'RPC error: Invalid user operation hash',
+    });
+  });
+
   it('should handle RPC errors gracefully', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       json: async () => ({

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
@@ -105,6 +105,11 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
         }),
       }).then((res) => res.json());
 
+      if (userOpResponse.error) {
+        const errorMessage = userOpResponse.error.message || 'Network error';
+        throw new Error(`RPC error: ${errorMessage}`);
+      }
+
       if (userOpResponse.result) {
         // UserOp exists but no receipt yet - it's pending
         if (telemetry) {


### PR DESCRIPTION
## Summary

- detect JSON-RPC errors returned by `eth_getUserOperationByHash`
- propagate them instead of reporting the payment as `not_found`
- add regression coverage for the error and telemetry paths

## Why

When the receipt lookup returned `null`, the follow-up user-operation lookup ignored its JSON-RPC `error` field. A bundler failure could therefore be misreported as a missing operation.

## Agent impact

Autonomous agents need to distinguish a genuinely absent user operation from an RPC failure before deciding whether to retry, alert, or advance a payment workflow. Accurate failure semantics are foundational for safe agent-run payment loops.

## Validation

- focused payment-status suite: 20 tests passed
- package typecheck
- package build
- Biome check on changed files