### PR TITLE
fix: reject malformed payment amount strings

### DIFF
--- a/packages/account-sdk/src/interface/payment/utils/validation.test.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.test.ts
@@ -13,12 +13,24 @@ describe('validateStringAmount', () => {
 
   it('should reject invalid amounts', () => {
     expect(() => validateStringAmount('0', 6)).toThrow('Invalid amount: must be greater than 0');
+    expect(() => validateStringAmount('00.000000', 6)).toThrow(
+      'Invalid amount: must be greater than 0'
+    );
     expect(() => validateStringAmount('-10', 6)).toThrow('Invalid amount: must be greater than 0');
     expect(() => validateStringAmount('abc', 6)).toThrow('Invalid amount: must be a valid number');
     expect(() => validateStringAmount('10.1234567', 6)).toThrow(
       'Invalid amount: pay only supports up to 6 decimal places'
     );
   });
+
+  it.each(['1abc', '1foo', '1.2.3', '1e6', '1.', '.1', '.', '', ' 1', '1 ', 'Infinity'])(
+    'should reject malformed amount %s',
+    (amount) => {
+      expect(() => validateStringAmount(amount, 6)).toThrow(
+        'Invalid amount: must be a valid number'
+      );
+    }
+  );
 
   it('should reject non-string amounts', () => {
     expect(() => validateStringAmount(10 as any, 6)).toThrow('Invalid amount: must be a string');

--- a/packages/account-sdk/src/interface/payment/utils/validation.ts
+++ b/packages/account-sdk/src/interface/payment/utils/validation.ts
@@ -11,13 +11,11 @@ export function validateStringAmount(amount: string, maxDecimals: number): void 
     throw new Error('Invalid amount: must be a string');
   }
 
-  const numAmount = parseFloat(amount);
-
-  if (isNaN(numAmount)) {
+  if (!/^-?\d+(?:\.\d+)?$/.test(amount)) {
     throw new Error('Invalid amount: must be a valid number');
   }
 
-  if (numAmount <= 0) {
+  if (amount.startsWith('-') || !/[1-9]/.test(amount)) {
     throw new Error('Invalid amount: must be greater than 0');
   }
 


### PR DESCRIPTION
## Summary

- replace partial `parseFloat` validation with strict decimal-string validation
- reject trailing junk, multiple decimal points, exponent notation, incomplete decimals, whitespace, and non-finite values
- preserve the existing negative, zero, and maximum-decimal error behavior
- add regression coverage for malformed payment inputs

## Root cause

`parseFloat` accepts a valid numeric prefix and ignores trailing invalid characters. Values such as `1abc` and `1.2.3` could therefore pass initial validation and fail later during transaction encoding.

## Agent impact

At the AI-agent frontier, tool-generated payment inputs must fail closed. Strict decimal validation prevents malformed model output from reaching transaction encoding or producing ambiguous payment failures.

Fixes #313.

## Validation

- focused validation suite: 22 tests passed
- account SDK typecheck
- account SDK build
- Biome formatting and lint checks on changed files

## AI assistance

Codex assisted with implementation and regression-test preparation. I reviewed the public issue, surrounding validation behavior, test results, and final diff before submission.
