### PR TITLE
fix(prolink): export createProlinkUrl from Node builds

### DIFF
--- a/packages/account-sdk/src/index.node.ts
+++ b/packages/account-sdk/src/index.node.ts
@@ -44,3 +44,14 @@ export type {
   SubscriptionStatus,
   SubscriptionStatusOptions,
 } from './interface/payment/index.node.js';
+
+// Prolink exports - Node version using Node.js zlib compression
+export {
+  createProlinkUrl,
+  decodeProlink,
+  encodeProlink,
+} from './interface/public-utilities/prolink/index.node.js';
+export type {
+  ProlinkDecoded,
+  ProlinkRequest,
+} from './interface/public-utilities/prolink/index.node.js';

--- a/packages/account-sdk/src/interface/public-utilities/prolink/createProlinkUrl.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/prolink/createProlinkUrl.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { createProlinkUrl } from './createProlinkUrl.js';
-import { encodeProlink } from './index.node.js';
+import { createProlinkUrl as createProlinkUrlFromNodeEntry, encodeProlink } from './index.node.js';
 
 describe('createProlinkUrl', () => {
   const EXAMPLE_PROLINK = 'CAEQhUIgAigFcn0KFKqqqqqqqqqqqqqqqqqqqqqqqqqqEhQxlx8zf';
@@ -250,6 +250,22 @@ describe('createProlinkUrl', () => {
       expect(url.pathname).toBe('/path/to/pay');
       expect(url.hash).toBe('#section');
       expect(url.searchParams.get('p')).toBe(EXAMPLE_PROLINK);
+    });
+  });
+
+  describe('node entry point re-export', () => {
+    it('should be importable from the node entry point and produce the same URL', async () => {
+      expect(typeof createProlinkUrlFromNodeEntry).toBe('function');
+
+      const prolink = await encodeProlink({
+        method: 'personal_sign',
+        params: ['0xdeadbeef', '0xfe21034794a5A574B94fE4fDfD16e005F1C96e51'],
+        chainId: 8453,
+      });
+      const result = createProlinkUrlFromNodeEntry(prolink);
+
+      expect(result).toBe(createProlinkUrl(prolink));
+      expect(new URL(result).searchParams.get('p')).toBe(prolink);
     });
   });
 });

--- a/packages/account-sdk/src/interface/public-utilities/prolink/index.node.ts
+++ b/packages/account-sdk/src/interface/public-utilities/prolink/index.node.ts
@@ -205,5 +205,8 @@ export async function decodeProlink(payload: string): Promise<ProlinkDecoded> {
   throw new Error(`Unsupported shortcut ID: ${rpcPayload.shortcutId}`);
 }
 
+// Re-export universal link utilities
+export { createProlinkUrl } from './createProlinkUrl.js';
+
 // Re-export types
 export type { ProlinkDecoded, ProlinkRequest } from './types.js';


### PR DESCRIPTION
## Summary

`createProlinkUrl` is unreachable from Node. It is re-exported from the browser prolink build but not from the Node one, and the root Node entrypoint does not re-export the prolink utilities at all. This makes the import shown in the docs fail on Node.

Addresses item 1 of #368.

    SyntaxError: The requested module '@base-org/account/prolink' does not provide an export named 'createProlinkUrl'

## Root cause

`exports["./prolink"].node` resolves to `dist/interface/public-utilities/prolink/index.node.js`, and that file never re-exported `createProlinkUrl`:

- `src/interface/public-utilities/prolink/index.ts:207-208` has `export { createProlinkUrl } from './createProlinkUrl.js';`
- `src/interface/public-utilities/prolink/index.node.ts` does not

The same asymmetry exists one level up:

- `src/index.ts:50-58` exports `createProlinkUrl`, `encodeProlink`, `decodeProlink`
- `src/index.node.ts` exports none of them

Confirmed against the published artifact, not just the source. `@base-org/account@2.5.7/dist/interface/public-utilities/prolink/index.node.js` contains only `encodeProlink` and `decodeProlink`.

## Changes

1. `src/interface/public-utilities/prolink/index.node.ts` re-exports `createProlinkUrl`, matching `index.ts`.
2. `src/index.node.ts` re-exports the prolink utilities from `./interface/public-utilities/prolink/index.node.js`, so the root Node entrypoint matches the browser root.
3. Added a regression test to the existing `createProlinkUrl.test.ts`, which already imported from `./index.node.js`. No new test file.

`createProlinkUrl.ts` has zero imports. It builds a URL with `URL` / `URLSearchParams`, both global in Node, and the package already requires `engines.node: ">=20"`. It has no compression dependency, so the re-export cannot pull the brotli-wasm path into the Node bundle. Importing from `index.node.js` in the root keeps Node on `utils/compression.node.js`.

## Test plan

| Command | Result |
| --- | --- |
| `typecheck` | pass |
| `lint` | pass (one pre-existing `noExplicitAny` warning in `subscribe.ts:98`, untouched) |
| `test` | 1001 tests across 73 files pass |
| `build` | pass |

The new test is a real guard: removing the re-export makes it fail, restoring it makes it pass.

Verified in the built output:

    dist/interface/public-utilities/prolink/index.node.js:170
      export { createProlinkUrl } from './createProlinkUrl.js';

    dist/index.node.js:8
      export { createProlinkUrl, decodeProlink, encodeProlink } from './interface/public-utilities/prolink/index.node.js';

Smoke-tested the built `dist` in Node:

    prolink/index.node.js exports: createProlinkUrl, decodeProlink, encodeProlink
    root index.node.js has createProlinkUrl: function

## Notes

Two things from #368 deliberately left out of this PR:

- **Item 2 (sub-account `personal_sign` / Storybook).** The referenced `storybook/stories/components/smart-wallet/SubAccount.tsx` does not exist in this repo, and there is no `storybook/` directory. Every sub-account `personal_sign` example in the repo already hex-encodes correctly (`examples/testapp/src/pages/add-sub-account/components/PersonalSign.tsx:22-25`, `import-sub-account/components/PersonalSign.tsx:21-24`, `e2e-test/tests/sub-account-features.ts:170-173`, `auto-sub-account/index.page.tsx:218-223`). The hex requirement itself is intentional and locked by tests in `createSubAccountSigner.test.ts:334-341` and `:361-382`, so changing it would be breaking. Left for separate discussion on the issue.
- **The reporter's "not exported from the root at all" claim** is broader than the actual bug. The browser root does export all three. Only the Node root did not, which this PR fixes.
