### PR TITLE
fix: remove embedded RPC keys from getPaymentStatus

### DIFF
--- a/packages/account-sdk/src/interface/payment/constants.ts
+++ b/packages/account-sdk/src/interface/payment/constants.ts
@@ -20,6 +20,20 @@ export const CHAIN_IDS = {
 } as const;
 
 /**
+ * Default bundler endpoints for payment status checks
+ */
+export const DEFAULT_BUNDLER_URLS = {
+  base: 'https://chain-proxy.wallet.coinbase.com?targetName=base',
+  baseSepolia: 'https://chain-proxy.wallet.coinbase.com?targetName=base-sepolia',
+} as const;
+
+/** Default request headers for payment status checks */
+export const DEFAULT_BUNDLER_HEADERS = {
+  'x-tpp-client-project-name': 'base-pay-sdk',
+  'x-tpp-client-feature-name': 'payment-status',
+} as const;
+
+/**
  * ERC20 transfer function ABI
  */
 export const ERC20_TRANSFER_ABI = [

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_BUNDLER_HEADERS, DEFAULT_BUNDLER_URLS } from './constants.js';
 import { getPaymentStatus } from './getPaymentStatus.js';
 import type { PaymentStatus } from './types.js';
 
@@ -11,6 +12,11 @@ vi.mock(':core/telemetry/events/payment.js', () => ({
   logPaymentStatusCheckCompleted: vi.fn(),
   logPaymentStatusCheckError: vi.fn(),
 }));
+
+const defaultBundlerHeaders = {
+  'Content-Type': 'application/json',
+  ...DEFAULT_BUNDLER_HEADERS,
+};
 
 describe('getPaymentStatus', () => {
   beforeEach(() => {
@@ -67,10 +73,10 @@ describe('getPaymentStatus', () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      'https://api.developer.coinbase.com/rpc/v1/base/S-fOd2n2Oi4fl4e1Crm83XeDXZ7tkg8O',
+      DEFAULT_BUNDLER_URLS.base,
       expect.objectContaining({
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: defaultBundlerHeaders,
         body: JSON.stringify({
           jsonrpc: '2.0',
           id: 1,
@@ -213,8 +219,10 @@ describe('getPaymentStatus', () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      'https://api.developer.coinbase.com/rpc/v1/base-sepolia/S-fOd2n2Oi4fl4e1Crm83XeDXZ7tkg8O',
-      expect.any(Object)
+      DEFAULT_BUNDLER_URLS.baseSepolia,
+      expect.objectContaining({
+        headers: defaultBundlerHeaders,
+      })
     );
   });
 
@@ -619,10 +627,7 @@ describe('getPaymentStatus', () => {
       );
 
       // Verify default bundler URL was NOT used
-      expect(fetch).not.toHaveBeenCalledWith(
-        'https://api.developer.coinbase.com/rpc/v1/base/S-fOd2n2Oi4fl4e1Crm83XeDXZ7tkg8O',
-        expect.anything()
-      );
+      expect(fetch).not.toHaveBeenCalledWith(DEFAULT_BUNDLER_URLS.base, expect.anything());
     });
 
     it('should use custom bundler URL for both receipt and pending checks', async () => {
@@ -701,8 +706,10 @@ describe('getPaymentStatus', () => {
 
       // Verify default testnet bundler URL was used
       expect(fetch).toHaveBeenCalledWith(
-        'https://api.developer.coinbase.com/rpc/v1/base-sepolia/S-fOd2n2Oi4fl4e1Crm83XeDXZ7tkg8O',
-        expect.anything()
+        DEFAULT_BUNDLER_URLS.baseSepolia,
+        expect.objectContaining({
+          headers: defaultBundlerHeaders,
+        })
       );
     });
   });

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
@@ -6,8 +6,24 @@ import {
   logPaymentStatusCheckError,
   logPaymentStatusCheckStarted,
 } from ':core/telemetry/events/payment.js';
-import { ERC20_TRANSFER_ABI, TOKENS } from './constants.js';
+import {
+  DEFAULT_BUNDLER_HEADERS,
+  DEFAULT_BUNDLER_URLS,
+  ERC20_TRANSFER_ABI,
+  TOKENS,
+} from './constants.js';
 import type { PaymentStatus, PaymentStatusOptions } from './types.js';
+
+function getDefaultBundlerUrl(testnet: boolean): string {
+  return testnet ? DEFAULT_BUNDLER_URLS.baseSepolia : DEFAULT_BUNDLER_URLS.base;
+}
+
+function getBundlerRequestHeaders(usingDefaultBundlerUrl: boolean): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    ...(usingDefaultBundlerUrl ? DEFAULT_BUNDLER_HEADERS : {}),
+  };
+}
 
 /**
  * Check the status of a payment transaction using its transaction ID (userOp hash)
@@ -57,19 +73,14 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
   }
 
   try {
-    // Get the bundler URL - use custom URL if provided, otherwise use default based on network
-    const effectiveBundlerUrl =
-      bundlerUrl ||
-      (testnet
-        ? 'https://api.developer.coinbase.com/rpc/v1/base-sepolia/S-fOd2n2Oi4fl4e1Crm83XeDXZ7tkg8O'
-        : 'https://api.developer.coinbase.com/rpc/v1/base/S-fOd2n2Oi4fl4e1Crm83XeDXZ7tkg8O');
+    const usingDefaultBundlerUrl = !bundlerUrl;
+    const effectiveBundlerUrl = bundlerUrl || getDefaultBundlerUrl(testnet);
+    const headers = getBundlerRequestHeaders(usingDefaultBundlerUrl);
 
     // Call eth_getUserOperationReceipt via the bundler
     const receipt = await fetch(effectiveBundlerUrl, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify({
         jsonrpc: '2.0',
         id: 1,
@@ -94,9 +105,7 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
       // Try eth_getUserOperationByHash to see if it's in mempool
       const userOpResponse = await fetch(effectiveBundlerUrl, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers,
         body: JSON.stringify({
           jsonrpc: '2.0',
           id: 2,


### PR DESCRIPTION
## Summary
- Remove embedded CDP RPC proxy keys from `getPaymentStatus`
- Default status checks to `chain-proxy.wallet.coinbase.com` (`targetName=base` / `base-sepolia`)
- Preserve optional `bundlerUrl` override for custom endpoints

## Test plan
- [x] `yarn test src/interface/payment/getPaymentStatus.test.ts --run` (19/19 passed)
- [ ] Manual: `getPaymentStatus({ id, testnet: true })` against a known Base Sepolia userOp
- [ ] Confirm custom `bundlerUrl` still overrides the default endpoint
- [ ] Follow-up: rotate/revoke the previously embedded CDP proxy key once this ships


Made with [Cursor](https://cursor.com)