### PR TITLE
fix: bind subscription charge/revoke to spender and payer

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,18 +95,37 @@ console.log(`Next charge: ${status.nextPeriodStart}`);
 
 ### Charge a Subscription
 
+Store the subscription `id` on your backend against the authenticated user when they subscribe.
+Do not charge an arbitrary `id` supplied by the browser alone — treat it as a capability handle,
+not proof of ownership.
+
 ```typescript
 import { base } from '@base-org/account';
 
-// Prepare the charge (get the transaction data)
+// Browser / custom wallet path: prepare call data, then send from your subscription owner
 const chargeCalls = await base.subscription.prepareCharge({
-  id: subscription.id,
+  id: storedSubscriptionId,
   amount: '9.99',        // or 'max-remaining-charge'
-  testnet: true
+  testnet: true,
+  expectedSpender: subscriptionOwner,       // your app's spender address
+  expectedPayer: authenticatedUserAddress,  // subscriber wallet from your session
 });
 
 // Execute the charge using your wallet provider
 // (This step requires your app's wallet to execute the transaction)
+```
+
+```typescript
+import { base } from '@base-org/account/node';
+
+// Node path: charge() requires the permission spender to be your CDP smart wallet.
+// Pass expectedPayer to ensure the subscription belongs to the authenticated user.
+const charge = await base.subscription.charge({
+  id: storedSubscriptionId,
+  amount: '9.99',
+  testnet: true,
+  expectedPayer: authenticatedUserAddress,
+});
 ```
 
 

--- a/packages/account-sdk/src/interface/payment/charge.test.ts
+++ b/packages/account-sdk/src/interface/payment/charge.test.ts
@@ -104,13 +104,15 @@ describe('charge', () => {
         owner: mockEoaAccount,
       });
 
-      // Verify charge preparation
+      // Verify charge preparation (spender bound to CDP smart wallet)
       expect(prepareChargeModule.prepareCharge).toHaveBeenCalledWith({
         id: options.id,
         amount: options.amount,
         testnet: options.testnet,
         recipient: undefined,
         rpcUrl: undefined,
+        expectedSpender: mockSmartAccount.address,
+        expectedPayer: undefined,
       });
 
       // Verify network selection
@@ -179,6 +181,8 @@ describe('charge', () => {
         testnet: options.testnet,
         recipient: undefined,
         rpcUrl: undefined,
+        expectedSpender: mockSmartAccount.address,
+        expectedPayer: undefined,
       });
 
       expect(result.amount).toBe('max');
@@ -280,6 +284,8 @@ describe('charge', () => {
         testnet: options.testnet,
         recipient: recipientAddress,
         rpcUrl: undefined,
+        expectedSpender: mockSmartAccount.address,
+        expectedPayer: undefined,
       });
 
       // Verify that sendUserOperation was called with all calls from prepareCharge
@@ -335,6 +341,8 @@ describe('charge', () => {
         testnet: options.testnet,
         recipient: recipientAddress,
         rpcUrl: undefined,
+        expectedSpender: mockSmartAccount.address,
+        expectedPayer: undefined,
       });
 
       // Verify testnet network selection
@@ -374,6 +382,8 @@ describe('charge', () => {
         testnet: options.testnet,
         recipient: recipientAddress,
         rpcUrl: undefined,
+        expectedSpender: mockSmartAccount.address,
+        expectedPayer: undefined,
       });
 
       // Verify result
@@ -405,6 +415,8 @@ describe('charge', () => {
         testnet: options.testnet,
         recipient: undefined,
         rpcUrl: customRpcUrl,
+        expectedSpender: mockSmartAccount.address,
+        expectedPayer: undefined,
       });
 
       // Verify result
@@ -416,9 +428,51 @@ describe('charge', () => {
         subscriptionOwner: mockSmartAccount.address,
       });
     });
+
+    it('should pass expectedPayer through to prepareCharge', async () => {
+      const expectedPayer = '0x1111111111111111111111111111111111111111';
+      const options = {
+        id: '0x71319cd488f8e4f24687711ec5c95d9e0c1bacbf5c1064942937eba4c7cf2984',
+        amount: '9.99',
+        testnet: false,
+        expectedPayer: expectedPayer as any,
+        cdpApiKeyId: 'test-api-key',
+        cdpApiKeySecret: 'test-api-secret',
+        cdpWalletSecret: 'test-wallet-secret',
+      };
+
+      await charge(options);
+
+      expect(prepareChargeModule.prepareCharge).toHaveBeenCalledWith({
+        id: options.id,
+        amount: options.amount,
+        testnet: options.testnet,
+        recipient: undefined,
+        rpcUrl: undefined,
+        expectedSpender: mockSmartAccount.address,
+        expectedPayer,
+      });
+    });
   });
 
   describe('error handling', () => {
+    it('should reject when expectedSpender does not match the charging wallet', async () => {
+      const options = {
+        id: '0x71319cd488f8e4f24687711ec5c95d9e0c1bacbf5c1064942937eba4c7cf2984',
+        amount: '9.99',
+        testnet: false,
+        expectedSpender: '0x3333333333333333333333333333333333333333' as any,
+        cdpApiKeyId: 'test-api-key',
+        cdpApiKeySecret: 'test-api-secret',
+        cdpWalletSecret: 'test-wallet-secret',
+      };
+
+      await expect(charge(options)).rejects.toThrow(
+        `expectedSpender ${options.expectedSpender} does not match charging wallet ${mockSmartAccount.address}`
+      );
+      expect(prepareChargeModule.prepareCharge).not.toHaveBeenCalled();
+    });
+
     it('should throw error when CDP credentials are missing', async () => {
       (CdpClient as any).mockImplementation(() => {
         throw new Error('Missing required API credentials');

--- a/packages/account-sdk/src/interface/payment/charge.ts
+++ b/packages/account-sdk/src/interface/payment/charge.ts
@@ -32,18 +32,22 @@ import { sendUserOpAndWait } from './utils/sendUserOpAndWait.js';
  * @param options.paymasterUrl - Paymaster URL for sponsorship. Falls back to PAYMASTER_URL env var
  * @param options.recipient - Optional recipient address to receive the charged USDC
  * @param options.rpcUrl - Optional custom RPC URL to use for blockchain queries. Useful for avoiding rate limits on public endpoints.
+ * @param options.expectedPayer - Optional subscriber address that must own the subscription
  * @returns Promise<ChargeResult> - Result of the charge transaction
  * @throws Error if CDP credentials are missing, subscription not found, or charge fails
  *
  * @example
  * ```typescript
- * import { base } from '@base-org/account/payment';
+ * import { base } from '@base-org/account/node';
  *
- * // Using environment variables for credentials and paymaster
+ * // Using environment variables for credentials and paymaster.
+ * // Prefer a server-stored subscription id bound to the authenticated user.
+ * // Optionally pass expectedPayer to enforce that binding at charge time.
  * const charge = await base.subscription.charge({
- *   id: '0x71319cd488f8e4f24687711ec5c95d9e0c1bacbf5c1064942937eba4c7cf2984',
+ *   id: storedSubscriptionId,
  *   amount: '9.99',
- *   testnet: false
+ *   testnet: false,
+ *   expectedPayer: authenticatedUserAddress,
  * });
  * console.log(`Charged ${charge.amount} - Transaction: ${charge.id}`);
  *
@@ -95,6 +99,8 @@ export async function charge(options: ChargeOptions): Promise<ChargeResult> {
     paymasterUrl = process.env.PAYMASTER_URL,
     recipient,
     rpcUrl,
+    expectedSpender,
+    expectedPayer,
   } = options;
 
   // Step 1: Initialize CDP client with provided credentials or environment variables
@@ -108,8 +114,25 @@ export async function charge(options: ChargeOptions): Promise<ChargeResult> {
   // The wallet should have been created prior to executing a charge on it.
   const smartWallet = await getExistingSmartWalletOrThrow(cdpClient, walletName, 'charge');
 
+  // Always require the permission spender to be this CDP smart wallet. Callers may also
+  // pass expectedSpender explicitly; it must match the wallet used to execute the charge.
+  const chargingSpender = smartWallet.address as Address;
+  if (expectedSpender && expectedSpender.toLowerCase() !== chargingSpender.toLowerCase()) {
+    throw new Error(
+      `expectedSpender ${expectedSpender} does not match charging wallet ${chargingSpender}`
+    );
+  }
+
   // Step 3: Prepare the charge call data (including optional recipient transfer and custom RPC URL)
-  const chargeCalls = await prepareCharge({ id, amount, testnet, recipient, rpcUrl });
+  const chargeCalls = await prepareCharge({
+    id,
+    amount,
+    testnet,
+    recipient,
+    rpcUrl,
+    expectedSpender: chargingSpender,
+    expectedPayer,
+  });
 
   // Step 4: Get the network-scoped smart wallet
   const network = testnet ? 'base-sepolia' : 'base';

--- a/packages/account-sdk/src/interface/payment/prepareCharge.test.ts
+++ b/packages/account-sdk/src/interface/payment/prepareCharge.test.ts
@@ -214,4 +214,85 @@ describe('prepareCharge', () => {
     });
     expect(result).toEqual(mockCallData);
   });
+
+  it('should accept matching expectedSpender and expectedPayer', async () => {
+    const authorizedPermission = {
+      chainId: 8453,
+      permission: {
+        account: '0x1111111111111111111111111111111111111111',
+        spender: '0x2222222222222222222222222222222222222222',
+        token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      },
+      signature: '0xmocksignature',
+    } as SpendPermission;
+    const { fetchPermission, prepareSpendCallData } = await import(
+      '../public-utilities/spend-permission/index.js'
+    );
+    vi.mocked(fetchPermission).mockResolvedValue(authorizedPermission);
+    vi.mocked(prepareSpendCallData).mockResolvedValue(mockCallData);
+
+    const result = await prepareCharge({
+      id: '0xhash123',
+      amount: '10.50',
+      testnet: false,
+      expectedSpender: '0x2222222222222222222222222222222222222222' as any,
+      expectedPayer: '0x1111111111111111111111111111111111111111' as any,
+    });
+
+    expect(result).toEqual(mockCallData);
+  });
+
+  it('should reject mismatched expectedSpender', async () => {
+    const authorizedPermission = {
+      chainId: 8453,
+      permission: {
+        account: '0x1111111111111111111111111111111111111111',
+        spender: '0x2222222222222222222222222222222222222222',
+        token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      },
+      signature: '0xmocksignature',
+    } as SpendPermission;
+    const { fetchPermission, prepareSpendCallData } = await import(
+      '../public-utilities/spend-permission/index.js'
+    );
+    vi.mocked(fetchPermission).mockResolvedValue(authorizedPermission);
+    vi.mocked(prepareSpendCallData).mockClear();
+
+    await expect(
+      prepareCharge({
+        id: '0xhash123',
+        amount: '10.50',
+        testnet: false,
+        expectedSpender: '0x3333333333333333333333333333333333333333' as any,
+      })
+    ).rejects.toThrow(/Subscription spender/);
+    expect(prepareSpendCallData).not.toHaveBeenCalled();
+  });
+
+  it('should reject mismatched expectedPayer', async () => {
+    const authorizedPermission = {
+      chainId: 8453,
+      permission: {
+        account: '0x1111111111111111111111111111111111111111',
+        spender: '0x2222222222222222222222222222222222222222',
+        token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      },
+      signature: '0xmocksignature',
+    } as SpendPermission;
+    const { fetchPermission, prepareSpendCallData } = await import(
+      '../public-utilities/spend-permission/index.js'
+    );
+    vi.mocked(fetchPermission).mockResolvedValue(authorizedPermission);
+    vi.mocked(prepareSpendCallData).mockClear();
+
+    await expect(
+      prepareCharge({
+        id: '0xhash123',
+        amount: '10.50',
+        testnet: false,
+        expectedPayer: '0x3333333333333333333333333333333333333333' as any,
+      })
+    ).rejects.toThrow(/Subscription payer/);
+    expect(prepareSpendCallData).not.toHaveBeenCalled();
+  });
 });

--- a/packages/account-sdk/src/interface/payment/prepareCharge.ts
+++ b/packages/account-sdk/src/interface/payment/prepareCharge.ts
@@ -5,6 +5,7 @@ import {
 } from '../public-utilities/spend-permission/index.js';
 import { TOKENS } from './constants.js';
 import type { PrepareChargeOptions, PrepareChargeResult } from './types.js';
+import { assertPermissionAuthorization } from './utils/assertPermissionAuthorization.js';
 import { validateUSDCBasePermission } from './utils/validateUSDCBasePermission.js';
 
 /**
@@ -18,12 +19,18 @@ import { validateUSDCBasePermission } from './utils/validateUSDCBasePermission.j
  * - An approval call (if the permission is not yet active)
  * - A spend call to charge the subscription
  *
+ * A subscription ID is not an authorization token by itself. Store IDs server-side against the
+ * authenticated user at subscribe time, and pass `expectedSpender` / `expectedPayer` when the ID
+ * may come from an untrusted client.
+ *
  * @param options - Options for preparing the charge
  * @param options.id - The subscription ID (permission hash) returned from subscribe()
  * @param options.amount - Amount to charge as a string (e.g., "10.50") or 'max-remaining-charge'
  * @param options.testnet - Whether this permission is on testnet (Base Sepolia). Defaults to false (mainnet)
  * @param options.recipient - Optional recipient address to receive the charged USDC
  * @param options.rpcUrl - Optional custom RPC URL to use for blockchain queries. Useful for avoiding rate limits on public endpoints.
+ * @param options.expectedSpender - Optional address that must match the subscription spender
+ * @param options.expectedPayer - Optional address that must match the subscription payer
  * @returns Promise<PrepareChargeResult> - Array of call data for the charge
  * @throws Error if the subscription cannot be found or if the amount exceeds remaining allowance
  *
@@ -35,7 +42,9 @@ import { validateUSDCBasePermission } from './utils/validateUSDCBasePermission.j
  * const chargeCalls = await base.subscription.prepareCharge({
  *   id: '0x71319cd488f8e4f24687711ec5c95d9e0c1bacbf5c1064942937eba4c7cf2984',
  *   amount: '9.99',
- *   testnet: false
+ *   testnet: false,
+ *   expectedSpender: subscriptionOwner,
+ *   expectedPayer: authenticatedUserAddress,
  * });
  *
  * // Prepare to charge the full remaining charge
@@ -73,7 +82,15 @@ import { validateUSDCBasePermission } from './utils/validateUSDCBasePermission.j
  * ```
  */
 export async function prepareCharge(options: PrepareChargeOptions): Promise<PrepareChargeResult> {
-  const { id, amount, testnet = false, recipient, rpcUrl } = options;
+  const {
+    id,
+    amount,
+    testnet = false,
+    recipient,
+    rpcUrl,
+    expectedSpender,
+    expectedPayer,
+  } = options;
 
   // Fetch the permission using the subscription ID (permission hash)
   const permission = await fetchPermission({
@@ -87,6 +104,9 @@ export async function prepareCharge(options: PrepareChargeOptions): Promise<Prep
 
   // Validate this is a USDC permission on the correct network
   validateUSDCBasePermission(permission, testnet);
+
+  // Optionally bind the permission to a known spender and/or payer
+  assertPermissionAuthorization(permission, { expectedSpender, expectedPayer });
 
   // Determine the amount to pass to prepareSpendCallData
   let spendAmount: bigint | 'max-remaining-allowance';

--- a/packages/account-sdk/src/interface/payment/prepareRevoke.test.ts
+++ b/packages/account-sdk/src/interface/payment/prepareRevoke.test.ts
@@ -1,0 +1,96 @@
+import type { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
+import { describe, expect, it, vi } from 'vitest';
+import { prepareRevoke } from './prepareRevoke.js';
+
+vi.mock('../public-utilities/spend-permission/index.js', () => ({
+  fetchPermission: vi.fn(),
+  prepareRevokeCallData: vi.fn(),
+}));
+
+describe('prepareRevoke', () => {
+  const mockRevokeCall = {
+    to: '0xmock' as const,
+    data: '0xrevoke' as const,
+    value: 0n,
+  };
+
+  it('prepares revoke call data for a valid subscription', async () => {
+    const permission = {
+      chainId: 8453,
+      permission: {
+        account: '0x1111111111111111111111111111111111111111',
+        spender: '0x2222222222222222222222222222222222222222',
+        token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      },
+      signature: '0xmocksignature',
+    } as SpendPermission;
+    const { fetchPermission, prepareRevokeCallData } = await import(
+      '../public-utilities/spend-permission/index.js'
+    );
+    vi.mocked(fetchPermission).mockResolvedValue(permission);
+    vi.mocked(prepareRevokeCallData).mockResolvedValue(mockRevokeCall as any);
+
+    const result = await prepareRevoke({
+      id: '0xhash123',
+      testnet: false,
+      expectedSpender: '0x2222222222222222222222222222222222222222' as any,
+      expectedPayer: '0x1111111111111111111111111111111111111111' as any,
+    });
+
+    expect(fetchPermission).toHaveBeenCalledWith({ permissionHash: '0xhash123' });
+    expect(prepareRevokeCallData).toHaveBeenCalledWith(permission);
+    expect(result).toEqual(mockRevokeCall);
+  });
+
+  it('rejects mismatched expectedSpender', async () => {
+    const permission = {
+      chainId: 8453,
+      permission: {
+        account: '0x1111111111111111111111111111111111111111',
+        spender: '0x2222222222222222222222222222222222222222',
+        token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      },
+      signature: '0xmocksignature',
+    } as SpendPermission;
+    const { fetchPermission, prepareRevokeCallData } = await import(
+      '../public-utilities/spend-permission/index.js'
+    );
+    vi.mocked(fetchPermission).mockResolvedValue(permission);
+    vi.mocked(prepareRevokeCallData).mockClear();
+
+    await expect(
+      prepareRevoke({
+        id: '0xhash123',
+        testnet: false,
+        expectedSpender: '0x3333333333333333333333333333333333333333' as any,
+      })
+    ).rejects.toThrow(/Subscription spender/);
+    expect(prepareRevokeCallData).not.toHaveBeenCalled();
+  });
+
+  it('rejects mismatched expectedPayer', async () => {
+    const permission = {
+      chainId: 8453,
+      permission: {
+        account: '0x1111111111111111111111111111111111111111',
+        spender: '0x2222222222222222222222222222222222222222',
+        token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      },
+      signature: '0xmocksignature',
+    } as SpendPermission;
+    const { fetchPermission, prepareRevokeCallData } = await import(
+      '../public-utilities/spend-permission/index.js'
+    );
+    vi.mocked(fetchPermission).mockResolvedValue(permission);
+    vi.mocked(prepareRevokeCallData).mockClear();
+
+    await expect(
+      prepareRevoke({
+        id: '0xhash123',
+        testnet: false,
+        expectedPayer: '0x3333333333333333333333333333333333333333' as any,
+      })
+    ).rejects.toThrow(/Subscription payer/);
+    expect(prepareRevokeCallData).not.toHaveBeenCalled();
+  });
+});

--- a/packages/account-sdk/src/interface/payment/prepareRevoke.ts
+++ b/packages/account-sdk/src/interface/payment/prepareRevoke.ts
@@ -3,6 +3,7 @@ import {
   prepareRevokeCallData,
 } from '../public-utilities/spend-permission/index.js';
 import type { PrepareRevokeOptions, PrepareRevokeResult } from './types.js';
+import { assertPermissionAuthorization } from './utils/assertPermissionAuthorization.js';
 import { validateUSDCBasePermission } from './utils/validateUSDCBasePermission.js';
 
 /**
@@ -14,9 +15,14 @@ import { validateUSDCBasePermission } from './utils/validateUSDCBasePermission.j
  *
  * The resulting call data includes the encoded transaction to revoke the spend permission.
  *
+ * A subscription ID is not an authorization token by itself. Prefer server-stored IDs bound to the
+ * authenticated user, and pass `expectedSpender` / `expectedPayer` when the ID may be untrusted.
+ *
  * @param options - Options for preparing the revoke
  * @param options.id - The subscription ID (permission hash) returned from subscribe()
  * @param options.testnet - Whether this permission is on testnet (Base Sepolia). Defaults to false (mainnet)
+ * @param options.expectedSpender - Optional address that must match the subscription spender
+ * @param options.expectedPayer - Optional address that must match the subscription payer
  * @returns Promise<PrepareRevokeResult> - Call data for the revoke
  * @throws Error if the subscription cannot be found
  *
@@ -27,7 +33,8 @@ import { validateUSDCBasePermission } from './utils/validateUSDCBasePermission.j
  * // Prepare to revoke a subscription
  * const revokeCall = await base.subscription.prepareRevoke({
  *   id: '0x71319cd488f8e4f24687711ec5c95d9e0c1bacbf5c1064942937eba4c7cf2984',
- *   testnet: false
+ *   testnet: false,
+ *   expectedSpender: subscriptionOwner,
  * });
  *
  * // Send the call using your app's subscription owner account
@@ -43,7 +50,7 @@ import { validateUSDCBasePermission } from './utils/validateUSDCBasePermission.j
  * ```
  */
 export async function prepareRevoke(options: PrepareRevokeOptions): Promise<PrepareRevokeResult> {
-  const { id, testnet = false } = options;
+  const { id, testnet = false, expectedSpender, expectedPayer } = options;
 
   // Fetch the permission using the subscription ID (permission hash)
   const permission = await fetchPermission({
@@ -57,6 +64,9 @@ export async function prepareRevoke(options: PrepareRevokeOptions): Promise<Prep
 
   // Validate this is a USDC permission on the correct network
   validateUSDCBasePermission(permission, testnet);
+
+  // Optionally bind the permission to a known spender and/or payer
+  assertPermissionAuthorization(permission, { expectedSpender, expectedPayer });
 
   // Call the existing prepareRevokeCallData utility
   const callData = await prepareRevokeCallData(permission);

--- a/packages/account-sdk/src/interface/payment/revoke.test.ts
+++ b/packages/account-sdk/src/interface/payment/revoke.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as prepareRevokeModule from './prepareRevoke.js';
+import { revoke } from './revoke.js';
+
+vi.mock('@coinbase/cdp-sdk', () => ({
+  CdpClient: vi.fn(),
+}));
+
+vi.mock('./prepareRevoke.js', () => ({
+  prepareRevoke: vi.fn(),
+}));
+
+import { CdpClient } from '@coinbase/cdp-sdk';
+
+describe('revoke', () => {
+  const mockEoaAccount = {
+    address: '0x1234567890123456789012345678901234567890',
+  };
+
+  const mockSmartAccount = {
+    address: '0xabcdef1234567890123456789012345678901234',
+    useNetwork: vi.fn(),
+  };
+
+  const mockNetworkSmartAccount = {
+    sendUserOperation: vi.fn(),
+    waitForUserOperation: vi.fn(),
+  };
+
+  const mockCdpClient = {
+    evm: {
+      getAccount: vi.fn(),
+      getSmartAccount: vi.fn(),
+    },
+  };
+
+  const mockRevokeCall = {
+    to: '0xabc123' as any,
+    data: '0xdef456' as any,
+    value: 0n,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (CdpClient as any).mockImplementation(() => mockCdpClient);
+    mockCdpClient.evm.getAccount.mockResolvedValue(mockEoaAccount);
+    mockCdpClient.evm.getSmartAccount.mockResolvedValue(mockSmartAccount);
+    mockSmartAccount.useNetwork.mockResolvedValue(mockNetworkSmartAccount);
+    mockNetworkSmartAccount.sendUserOperation.mockResolvedValue({
+      smartAccountAddress: mockSmartAccount.address,
+      status: 'broadcast',
+      userOpHash: '0x9876543210987654321098765432109876543210987654321098765432109876',
+    });
+    mockNetworkSmartAccount.waitForUserOperation.mockResolvedValue({
+      smartAccountAddress: mockSmartAccount.address,
+      status: 'complete',
+      userOpHash: '0x9876543210987654321098765432109876543210987654321098765432109876',
+      transactionHash: '0xabcdef1234567890123456789012345678901234567890123456789012345678',
+    });
+    (prepareRevokeModule.prepareRevoke as any).mockResolvedValue(mockRevokeCall);
+  });
+
+  it('binds expectedSpender to the CDP smart wallet', async () => {
+    const options = {
+      id: '0x71319cd488f8e4f24687711ec5c95d9e0c1bacbf5c1064942937eba4c7cf2984',
+      testnet: false,
+      cdpApiKeyId: 'test-api-key',
+      cdpApiKeySecret: 'test-api-secret',
+      cdpWalletSecret: 'test-wallet-secret',
+    };
+
+    await revoke(options);
+
+    expect(prepareRevokeModule.prepareRevoke).toHaveBeenCalledWith({
+      id: options.id,
+      testnet: options.testnet,
+      expectedSpender: mockSmartAccount.address,
+      expectedPayer: undefined,
+    });
+  });
+
+  it('passes expectedPayer through to prepareRevoke', async () => {
+    const expectedPayer = '0x1111111111111111111111111111111111111111';
+    const options = {
+      id: '0x71319cd488f8e4f24687711ec5c95d9e0c1bacbf5c1064942937eba4c7cf2984',
+      testnet: false,
+      expectedPayer: expectedPayer as any,
+      cdpApiKeyId: 'test-api-key',
+      cdpApiKeySecret: 'test-api-secret',
+      cdpWalletSecret: 'test-wallet-secret',
+    };
+
+    await revoke(options);
+
+    expect(prepareRevokeModule.prepareRevoke).toHaveBeenCalledWith({
+      id: options.id,
+      testnet: options.testnet,
+      expectedSpender: mockSmartAccount.address,
+      expectedPayer,
+    });
+  });
+
+  it('rejects when expectedSpender does not match the revoking wallet', async () => {
+    const options = {
+      id: '0x71319cd488f8e4f24687711ec5c95d9e0c1bacbf5c1064942937eba4c7cf2984',
+      testnet: false,
+      expectedSpender: '0x3333333333333333333333333333333333333333' as any,
+      cdpApiKeyId: 'test-api-key',
+      cdpApiKeySecret: 'test-api-secret',
+      cdpWalletSecret: 'test-wallet-secret',
+    };
+
+    await expect(revoke(options)).rejects.toThrow(
+      `expectedSpender ${options.expectedSpender} does not match revoking wallet ${mockSmartAccount.address}`
+    );
+    expect(prepareRevokeModule.prepareRevoke).not.toHaveBeenCalled();
+  });
+});

--- a/packages/account-sdk/src/interface/payment/revoke.ts
+++ b/packages/account-sdk/src/interface/payment/revoke.ts
@@ -29,17 +29,19 @@ import { sendUserOpAndWait } from './utils/sendUserOpAndWait.js';
  * @param options.cdpWalletSecret - CDP wallet secret. Falls back to CDP_WALLET_SECRET env var
  * @param options.walletName - Custom wallet name. Defaults to "subscription owner"
  * @param options.paymasterUrl - Paymaster URL for sponsorship. Falls back to PAYMASTER_URL env var
+ * @param options.expectedPayer - Optional subscriber address that must own the subscription
  * @returns Promise<RevokeResult> - Result of the revoke transaction
  * @throws Error if CDP credentials are missing, subscription not found, or revoke fails
  *
  * @example
  * ```typescript
- * import { base } from '@base-org/account/payment';
+ * import { base } from '@base-org/account/node';
  *
  * // Using environment variables for credentials and paymaster
  * const result = await base.subscription.revoke({
- *   id: '0x71319cd488f8e4f24687711ec5c95d9e0c1bacbf5c1064942937eba4c7cf2984',
- *   testnet: false
+ *   id: storedSubscriptionId,
+ *   testnet: false,
+ *   expectedPayer: authenticatedUserAddress,
  * });
  * console.log(`Revoked subscription - Transaction: ${result.id}`);
  *
@@ -70,6 +72,8 @@ export async function revoke(options: RevokeOptions): Promise<RevokeResult> {
     cdpWalletSecret,
     walletName = 'subscription owner',
     paymasterUrl = process.env.PAYMASTER_URL,
+    expectedSpender,
+    expectedPayer,
   } = options;
 
   // Step 1: Initialize CDP client with provided credentials or environment variables
@@ -83,8 +87,20 @@ export async function revoke(options: RevokeOptions): Promise<RevokeResult> {
   // The wallet should have been created prior to executing a revoke on it.
   const smartWallet = await getExistingSmartWalletOrThrow(cdpClient, walletName, 'revoke');
 
+  const revokingSpender = smartWallet.address as Address;
+  if (expectedSpender && expectedSpender.toLowerCase() !== revokingSpender.toLowerCase()) {
+    throw new Error(
+      `expectedSpender ${expectedSpender} does not match revoking wallet ${revokingSpender}`
+    );
+  }
+
   // Step 3: Prepare the revoke call data
-  const revokeCall = await prepareRevoke({ id, testnet });
+  const revokeCall = await prepareRevoke({
+    id,
+    testnet,
+    expectedSpender: revokingSpender,
+    expectedPayer,
+  });
 
   // Step 4: Get the network-scoped smart wallet
   const network = testnet ? 'base-sepolia' : 'base';

--- a/packages/account-sdk/src/interface/payment/types.ts
+++ b/packages/account-sdk/src/interface/payment/types.ts
@@ -300,6 +300,16 @@ export interface PrepareChargeOptions {
   recipient?: Address;
   /** Optional custom RPC URL to use for blockchain queries. Useful for avoiding rate limits on public endpoints. */
   rpcUrl?: string;
+  /**
+   * If set, the subscription's spender (subscription owner) must match this address.
+   * `charge()` sets this automatically to your CDP smart wallet.
+   */
+  expectedSpender?: Address;
+  /**
+   * If set, the subscription's payer (subscriber account) must match this address.
+   * Pass the authenticated user's wallet so you only charge subscriptions belonging to them.
+   */
+  expectedPayer?: Address;
 }
 
 /**
@@ -389,6 +399,16 @@ export interface PrepareRevokeOptions {
   id: string;
   /** Whether to use testnet (Base Sepolia). Defaults to false (mainnet) */
   testnet?: boolean;
+  /**
+   * If set, the subscription's spender (subscription owner) must match this address.
+   * `revoke()` sets this automatically to your CDP smart wallet.
+   */
+  expectedSpender?: Address;
+  /**
+   * If set, the subscription's payer (subscriber account) must match this address.
+   * Pass the authenticated user's wallet so you only revoke subscriptions belonging to them.
+   */
+  expectedPayer?: Address;
 }
 
 /**

--- a/packages/account-sdk/src/interface/payment/utils/assertPermissionAuthorization.test.ts
+++ b/packages/account-sdk/src/interface/payment/utils/assertPermissionAuthorization.test.ts
@@ -1,0 +1,83 @@
+import type { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
+import { describe, expect, it } from 'vitest';
+import { assertPermissionAuthorization } from './assertPermissionAuthorization.js';
+
+describe('assertPermissionAuthorization', () => {
+  const permission = {
+    chainId: 8453,
+    permission: {
+      account: '0x1111111111111111111111111111111111111111',
+      spender: '0x2222222222222222222222222222222222222222',
+      token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      allowance: '1000000',
+      period: 86400,
+      start: 0,
+      end: 0,
+      salt: '0x0',
+      extraData: '0x',
+    },
+    signature: '0xmocksignature',
+  } as SpendPermission;
+
+  it('does nothing when no checks are provided', () => {
+    expect(() => assertPermissionAuthorization(permission, {})).not.toThrow();
+  });
+
+  it('accepts a matching spender (case-insensitive)', () => {
+    expect(() =>
+      assertPermissionAuthorization(permission, {
+        expectedSpender: '0x2222222222222222222222222222222222222222',
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      assertPermissionAuthorization(permission, {
+        expectedSpender: '0x2222222222222222222222222222222222222222'.toUpperCase(),
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects a mismatched spender', () => {
+    expect(() =>
+      assertPermissionAuthorization(permission, {
+        expectedSpender: '0x3333333333333333333333333333333333333333',
+      })
+    ).toThrow(
+      'Subscription spender 0x2222222222222222222222222222222222222222 does not match expected spender 0x3333333333333333333333333333333333333333'
+    );
+  });
+
+  it('accepts a matching payer (case-insensitive)', () => {
+    expect(() =>
+      assertPermissionAuthorization(permission, {
+        expectedPayer: '0x1111111111111111111111111111111111111111',
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects a mismatched payer', () => {
+    expect(() =>
+      assertPermissionAuthorization(permission, {
+        expectedPayer: '0x3333333333333333333333333333333333333333',
+      })
+    ).toThrow(
+      'Subscription payer 0x1111111111111111111111111111111111111111 does not match expected payer 0x3333333333333333333333333333333333333333'
+    );
+  });
+
+  it('checks both spender and payer when both are provided', () => {
+    expect(() =>
+      assertPermissionAuthorization(permission, {
+        expectedSpender: '0x2222222222222222222222222222222222222222',
+        expectedPayer: '0x1111111111111111111111111111111111111111',
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      assertPermissionAuthorization(permission, {
+        expectedSpender: '0x2222222222222222222222222222222222222222',
+        expectedPayer: '0x3333333333333333333333333333333333333333',
+      })
+    ).toThrow(/Subscription payer/);
+  });
+});

--- a/packages/account-sdk/src/interface/payment/utils/assertPermissionAuthorization.ts
+++ b/packages/account-sdk/src/interface/payment/utils/assertPermissionAuthorization.ts
@@ -1,0 +1,40 @@
+import type { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
+import type { Address } from 'viem';
+
+export type PermissionAuthorizationChecks = {
+  /** If set, must equal the subscription spender (subscription owner). */
+  expectedSpender?: Address | string;
+  /** If set, must equal the subscription payer (subscriber account). */
+  expectedPayer?: Address | string;
+};
+
+/**
+ * Asserts that a spend permission matches optional expected spender/payer addresses.
+ *
+ * Use this when a subscription ID comes from an untrusted source (e.g. a browser client)
+ * so callers can bind the permission to a known subscription owner and/or subscriber.
+ */
+export function assertPermissionAuthorization(
+  permission: SpendPermission,
+  checks: PermissionAuthorizationChecks
+): void {
+  const { expectedSpender, expectedPayer } = checks;
+
+  if (expectedSpender) {
+    const actualSpender = permission.permission.spender;
+    if (actualSpender.toLowerCase() !== expectedSpender.toLowerCase()) {
+      throw new Error(
+        `Subscription spender ${actualSpender} does not match expected spender ${expectedSpender}`
+      );
+    }
+  }
+
+  if (expectedPayer) {
+    const actualPayer = permission.permission.account;
+    if (actualPayer.toLowerCase() !== expectedPayer.toLowerCase()) {
+      throw new Error(
+        `Subscription payer ${actualPayer} does not match expected payer ${expectedPayer}`
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `charge()` and `revoke()` now require the subscription permission’s spender to match the CDP smart wallet executing the call
- Add optional `expectedSpender` / `expectedPayer` on `prepareCharge` / `prepareRevoke` (and Node execute APIs) so backends can bind a subscription ID to a known owner and subscriber
- Document that subscription IDs should be stored server-side against the authenticated user, not treated as proof of ownership when supplied by the browser

## Test plan
- [x] Unit tests for `assertPermissionAuthorization`
- [x] `prepareCharge` / `charge` spender and payer mismatch + happy-path coverage
- [x] `prepareRevoke` / `revoke` spender and payer mismatch + CDP wallet binding
- [ ] Manual: Node `charge()` with a permission whose spender ≠ CDP wallet fails before send
- [ ] Manual: `charge({ expectedPayer })` rejects a subscription belonging to a different account


Made with [Cursor](https://cursor.com)