### PR TITLE
fix: fail closed on unverifiable payments (SECBUGS-14988)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ const status = await getPaymentStatus({
 console.log(`Payment status: ${status.status}`);
 ```
 
-`expectedPayment` is optional for backward compatibility, but production merchants should always
-provide trusted order values. Without it, `completed` only confirms that the operation contained a
-positive USDC transfer; it does not confirm the order's amount or recipient.
+Run this check on your backend before fulfillment. `expectedPayment` is optional for backward
+compatibility, but production merchants should always provide trusted order values. Without it,
+`completed` only confirms that the operation contained a positive USDC transfer; it does not confirm
+the order's amount or recipient. Bind each payment ID to one order and reject IDs that have already
+been used for fulfillment.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,19 @@ import { getPaymentStatus } from '@base-org/account';
 
 const status = await getPaymentStatus({
   id: payment.id,
+  expectedPayment: {
+    amount: "10.50",                                 // From your server-side order
+    recipient: "0xYourWalletAddress"
+  },
   testnet: true
 });
 
 console.log(`Payment status: ${status.status}`);
 ```
+
+`expectedPayment` is optional for backward compatibility, but production merchants should always
+provide trusted order values. Without it, `completed` only confirms that the operation contained a
+positive USDC transfer; it does not confirm the order's amount or recipient.
 
 ---
 

--- a/examples/testapp/src/pages/e2e-test/tests/payment-features.ts
+++ b/examples/testapp/src/pages/e2e-test/tests/payment-features.ts
@@ -63,9 +63,11 @@ export async function testGetPaymentStatus(
     async (ctx) => {
       const status = await ctx.loadedSDK.getPaymentStatus({
         id: ctx.paymentId!,
+        expectedPayment: {
+          amount: '0.01',
+          recipient: '0x0000000000000000000000000000000000000001',
+        },
         testnet: true,
-        maxRetries: 10, // Retry up to 10 times
-        retryDelayMs: 500, // 500ms between retries = ~5 seconds total
       });
 
       const details = [

--- a/examples/testapp/src/pages/e2e-test/types.ts
+++ b/examples/testapp/src/pages/e2e-test/types.ts
@@ -85,9 +85,11 @@ export interface PrepareChargeOptions {
 
 export interface GetPaymentStatusOptions {
   id: string;
+  expectedPayment?: {
+    amount: string;
+    recipient: string;
+  };
   testnet?: boolean;
-  maxRetries?: number;
-  retryDelayMs?: number;
 }
 
 export interface GetSubscriptionStatusOptions {

--- a/examples/testapp/src/pages/pay-playground/constants/playground.ts
+++ b/examples/testapp/src/pages/pay-playground/constants/playground.ts
@@ -42,12 +42,16 @@ export const DEFAULT_GET_PAYMENT_STATUS_CODE = `import { base } from '@base-org/
 try {
   const result = await base.getPaymentStatus({
     id: '0x...', // Replace with a transaction ID
+    expectedPayment: {
+      amount: '.01', // Load from your server-side order in production
+      recipient: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
+    },
     testnet: true
   })
   
   return result;
 } catch (error) {
-  // This will catch network errors if any occur
+  // This catches network and payment verification errors
   console.error('Failed to check payment status:', error.message);
   throw error;
 }`;
@@ -66,6 +70,8 @@ export const GET_PAYMENT_STATUS_QUICK_TIPS = [
   'For completed payments, you can see the amount and recipient',
   'For failed payments, you can see the failure reason',
   'Make sure to use the same testnet setting as the original payment',
+  'In production, verify the server-side order amount and recipient before fulfillment',
+  'Store each completed payment ID and reject reuse',
 ];
 
 export const QUICK_TIPS = PAY_QUICK_TIPS;

--- a/examples/testapp/src/pages/pay-playground/index.page.tsx
+++ b/examples/testapp/src/pages/pay-playground/index.page.tsx
@@ -53,17 +53,23 @@ function PayPlayground() {
       payExecution.result.id
     ) {
       const transactionId = payExecution.result.id;
+      const amount = payExecution.result.amount;
+      const recipient = payExecution.result.to;
       const updatedCode = `import { base } from '@base-org/account'
 
 try {
   const result = await base.getPaymentStatus({
     id: '${transactionId}', // Automatically filled with your recent transaction
+    expectedPayment: {
+      amount: '${amount}',
+      recipient: '${recipient}'
+    },
     testnet: true
   })
   
   return result;
 } catch (error) {
-  // This will catch network errors if any occur
+  // This catches network and payment verification errors
   console.error('Failed to check payment status:', error.message);
   throw error;
 }`;

--- a/examples/testapp/src/pages/payment/index.page.tsx
+++ b/examples/testapp/src/pages/payment/index.page.tsx
@@ -26,6 +26,7 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import { useState } from 'react';
+import type { Address } from 'viem';
 import { useConfig } from '../../context/ConfigContextProvider';
 
 export default function Payment() {
@@ -68,6 +69,8 @@ export default function Payment() {
 
   // Status check state
   const [statusId, setStatusId] = useState('');
+  const [statusExpectedAmount, setStatusExpectedAmount] = useState('');
+  const [statusExpectedRecipient, setStatusExpectedRecipient] = useState('');
   const [statusLoading, setStatusLoading] = useState(false);
   const [statusResult, setStatusResult] = useState<PaymentStatus | null>(null);
   const [statusError, setStatusError] = useState<{ error: string; errorDetails?: unknown } | null>(
@@ -132,6 +135,8 @@ export default function Payment() {
         });
         // Auto-populate status check field
         setStatusId(result.id);
+        setStatusExpectedAmount(payAmount);
+        setStatusExpectedRecipient(payTo);
       } else {
         toast({
           title: 'Payment failed',
@@ -181,6 +186,16 @@ export default function Payment() {
       return;
     }
 
+    if (Boolean(statusExpectedAmount) !== Boolean(statusExpectedRecipient)) {
+      toast({
+        title: 'Incomplete expected payment',
+        description: 'Provide both the expected amount and recipient, or leave both empty',
+        status: 'error',
+        duration: 3000,
+      });
+      return;
+    }
+
     setStatusLoading(true);
     setStatusResult(null);
     setStatusError(null);
@@ -188,6 +203,13 @@ export default function Payment() {
     try {
       const result = await getPaymentStatus({
         id: statusId,
+        ...(statusExpectedAmount &&
+          statusExpectedRecipient && {
+            expectedPayment: {
+              amount: statusExpectedAmount,
+              recipient: statusExpectedRecipient as Address,
+            },
+          }),
         testnet: statusTestnet, // Use the separate status check testnet setting
       });
 
@@ -495,6 +517,30 @@ export default function Payment() {
                 fontFamily="mono"
                 size="lg"
               />
+            </FormControl>
+
+            <FormControl>
+              <FormLabel>Expected Amount (USDC, optional)</FormLabel>
+              <Input
+                placeholder="0.01"
+                value={statusExpectedAmount}
+                onChange={(e) => setStatusExpectedAmount(e.target.value)}
+                size="lg"
+              />
+            </FormControl>
+
+            <FormControl>
+              <FormLabel>Expected Recipient (optional)</FormLabel>
+              <Input
+                placeholder="0x..."
+                value={statusExpectedRecipient}
+                onChange={(e) => setStatusExpectedRecipient(e.target.value)}
+                fontFamily="mono"
+                size="lg"
+              />
+              <Text mt={2} fontSize="sm" color={noteTextColor}>
+                Production merchants should load both values from their server-side order.
+              </Text>
             </FormControl>
 
             <Button

--- a/packages/account-sdk/README.md
+++ b/packages/account-sdk/README.md
@@ -161,6 +161,7 @@ const status = await window.base.getPaymentStatus({
 const provider = window.createBaseAccountSDK().getProvider()
 ```
 
-For production payment verification, populate `expectedPayment` from trusted server-side order
-data. Omitting it preserves backward compatibility but does not verify the order amount or
-recipient.
+For production payment verification, call `getPaymentStatus` on your backend and populate
+`expectedPayment` from trusted server-side order data. Omitting it preserves backward compatibility
+but does not verify the order amount or recipient. Bind each payment ID to one order and reject IDs
+that have already been used for fulfillment.

--- a/packages/account-sdk/README.md
+++ b/packages/account-sdk/README.md
@@ -150,9 +150,17 @@ const result = await window.base.pay({
 // Check payment status
 const status = await window.base.getPaymentStatus({
   id: result.id,
+  expectedPayment: {
+    amount: "10.50",
+    recipient: "0xYourAddress..."
+  },
   testnet: true
 });
 
 // Create Base Account Provider
 const provider = window.createBaseAccountSDK().getProvider()
 ```
+
+For production payment verification, populate `expectedPayment` from trusted server-side order
+data. Omitting it preserves backward compatibility but does not verify the order amount or
+recipient.

--- a/packages/account-sdk/src/interface/payment/README.md
+++ b/packages/account-sdk/src/interface/payment/README.md
@@ -32,6 +32,10 @@ import { getPaymentStatus } from '@base/account-sdk';
 // Check payment status
 const status = await getPaymentStatus({
   id: payment.id,
+  expectedPayment: {
+    amount: "10.50",
+    recipient: "0xFe21034794A5a574B94fE4fDfD16e005F1C96e51"
+  },
   testnet: true
 });
 
@@ -50,6 +54,10 @@ switch (status.status) {
     break;
 }
 ```
+
+Use trusted server-side order values for `expectedPayment`. It is optional for backward
+compatibility, but omitting it only verifies that the operation contained a positive USDC transfer;
+it does not verify the order amount or recipient.
 
 ## Information Requests (Data Callbacks)
 
@@ -149,6 +157,8 @@ The payment result is always a successful payment (errors are thrown as exceptio
 #### PaymentStatusOptions
 
 - `id: string` - Transaction ID (userOp hash) to check status for
+- `expectedPayment?: { amount: string; recipient: Address }` - Trusted order details to verify
+  against the on-chain USDC transfer
 - `testnet?: boolean` - Whether to check on testnet (Base Sepolia). Defaults to false (mainnet)
 - `telemetry?: boolean` - Whether to enable telemetry logging (default: true)
 

--- a/packages/account-sdk/src/interface/payment/README.md
+++ b/packages/account-sdk/src/interface/payment/README.md
@@ -7,18 +7,17 @@ The payment interface provides a simple way to make USDC payments on Base networ
 ```typescript
 import { pay } from '@base-org/account';
 
-// Basic payment
-const payment = await pay({
-  amount: "10.50",
-  to: "0xFe21034794A5a574B94fE4fDfD16e005F1C96e51",
-  dataSuffix: "0xabc123",
-  testnet: true
-});
+try {
+  const payment = await pay({
+    amount: "10.50",
+    to: "0xFe21034794A5a574B94fE4fDfD16e005F1C96e51",
+    dataSuffix: "0xabc123",
+    testnet: true
+  });
 
-if (payment.success) {
-  console.log(`Payment sent! Transaction ID: ${payment.id}`);
-} else {
-  console.error(`Payment failed: ${payment.error}`);
+  console.info(`Payment sent! Transaction ID: ${payment.id}`);
+} catch (error) {
+  console.error(`Payment failed: ${error instanceof Error ? error.message : "Unknown error"}`);
 }
 ```
 
@@ -27,7 +26,7 @@ if (payment.success) {
 You can check the status of a payment using the transaction ID returned from the pay function:
 
 ```typescript
-import { getPaymentStatus } from '@base/account-sdk';
+import { getPaymentStatus } from '@base-org/account';
 
 // Check payment status
 const status = await getPaymentStatus({
@@ -47,7 +46,7 @@ switch (status.status) {
     console.log(`Payment completed! Amount: ${status.amount} to ${status.recipient}`);
     break;
   case 'failed':
-    console.log(`Payment failed: ${status.error}`);
+    console.log(`Payment failed: ${status.reason}`);
     break;
   case 'not_found':
     console.log('Payment not found');
@@ -57,7 +56,19 @@ switch (status.status) {
 
 Use trusted server-side order values for `expectedPayment`. It is optional for backward
 compatibility, but omitting it only verifies that the operation contained a positive USDC transfer;
-it does not verify the order amount or recipient.
+it does not verify the order amount or recipient. Bind each payment ID to one order and reject IDs
+that have already been used for fulfillment.
+
+### Production Verification
+
+- Call `getPaymentStatus()` on your backend before fulfilling an order.
+- Load `expectedPayment.amount` and `expectedPayment.recipient` from your server-side order record;
+  never accept these values from the payer.
+- Store the payment ID with the fulfilled order and reject an ID that has already been consumed.
+- Handle verification errors with `try/catch`. A returned `failed` status means the on-chain
+  operation failed; invalid or mismatched payment evidence throws instead.
+- Treat the returned `amount` as a normalized display value. Verification compares exact on-chain
+  USDC units rather than formatted strings.
 
 ## Information Requests (Data Callbacks)
 
@@ -115,6 +126,10 @@ const payment = await pay({
 // Disable telemetry for status check
 const status = await getPaymentStatus({
   id: payment.id,
+  expectedPayment: {
+    amount: "10.50",
+    recipient: "0xFe21034794A5a574B94fE4fDfD16e005F1C96e51"
+  },
   testnet: true,
   telemetry: false  // Opt out of telemetry
 });
@@ -158,9 +173,10 @@ The payment result is always a successful payment (errors are thrown as exceptio
 
 - `id: string` - Transaction ID (userOp hash) to check status for
 - `expectedPayment?: { amount: string; recipient: Address }` - Trusted order details to verify
-  against the on-chain USDC transfer
+  against the on-chain USDC transfer; `amount` must be positive with at most 6 decimal places
 - `testnet?: boolean` - Whether to check on testnet (Base Sepolia). Defaults to false (mainnet)
 - `telemetry?: boolean` - Whether to enable telemetry logging (default: true)
+- `bundlerUrl?: string` - Trusted custom bundler URL for status checks
 
 #### PaymentStatus
 
@@ -170,4 +186,4 @@ The payment result is always a successful payment (errors are thrown as exceptio
 - `sender?: string` - Sender address (present for pending, completed, and failed)
 - `amount?: string` - Amount sent (present for completed transactions, parsed from logs)
 - `recipient?: string` - Recipient address (present for completed transactions, parsed from logs)
-- `error?: string` - Error message (present for failed status - includes both on-chain failure reasons and off-chain errors) 
+- `reason?: string` - On-chain failure reason (present for failed status)

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
@@ -500,6 +500,43 @@ describe('getPaymentStatus', () => {
     expect(logPaymentStatusCheckCompleted).not.toHaveBeenCalled();
   });
 
+  it('should reject a scalar receipt result', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ jsonrpc: '2.0', id: 1, result: false }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xscalar-receipt-result',
+        testnet: false,
+      })
+    ).rejects.toThrow('RPC error: Invalid response');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject a scalar pending lookup result', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        json: async () => ({ jsonrpc: '2.0', id: 1, result: null }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ jsonrpc: '2.0', id: 2, result: true }),
+      } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xscalar-pending-result',
+        testnet: false,
+      })
+    ).rejects.toThrow('RPC error: Invalid response');
+
+    const { logPaymentStatusCheckCompleted } = await import(':core/telemetry/events/payment.js');
+    expect(logPaymentStatusCheckCompleted).not.toHaveBeenCalled();
+  });
+
   it('should handle network errors gracefully', async () => {
     vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
 

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
@@ -442,6 +442,64 @@ describe('getPaymentStatus', () => {
     });
   });
 
+  it('should reject non-successful HTTP responses', async () => {
+    const json = vi.fn();
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json,
+    } as unknown as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xhttp-error',
+        testnet: false,
+      })
+    ).rejects.toThrow('RPC request failed with HTTP status 401');
+
+    expect(json).not.toHaveBeenCalled();
+    const { logPaymentStatusCheckCompleted, logPaymentStatusCheckError } = await import(
+      ':core/telemetry/events/payment.js'
+    );
+    expect(logPaymentStatusCheckCompleted).not.toHaveBeenCalled();
+    expect(logPaymentStatusCheckError).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject a malformed receipt response without a result', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'Unauthorized' }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xmalformed-receipt-response',
+        testnet: false,
+      })
+    ).rejects.toThrow('RPC error: Invalid response');
+  });
+
+  it('should reject a malformed pending lookup response without a result', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        json: async () => ({ jsonrpc: '2.0', id: 1, result: null }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ message: 'Unauthorized' }),
+      } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xmalformed-pending-response',
+        testnet: false,
+      })
+    ).rejects.toThrow('RPC error: Invalid response');
+
+    const { logPaymentStatusCheckCompleted } = await import(':core/telemetry/events/payment.js');
+    expect(logPaymentStatusCheckCompleted).not.toHaveBeenCalled();
+  });
+
   it('should handle network errors gracefully', async () => {
     vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
 

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_BUNDLER_HEADERS, DEFAULT_BUNDLER_URLS, TOKENS } from './constants.js';
 import { getPaymentStatus } from './getPaymentStatus.js';
-import type { PaymentStatus } from './types.js';
+import type { PaymentStatus, PaymentStatusOptions } from './types.js';
 
 // Mock fetch globally
 global.fetch = vi.fn();
@@ -26,33 +26,46 @@ const paymentRecipientTopic = '0x000000000000000000000000f1ddf1fc0310cb11f0ca875
 function createUsdcTransferLog({
   testnet = false,
   value = '0x0000000000000000000000000000000000000000000000000000000000989680',
-}: { testnet?: boolean; value?: string } = {}) {
+  fromTopic = paymentSenderTopic,
+  recipientTopic = paymentRecipientTopic,
+}: {
+  testnet?: boolean;
+  value?: string;
+  fromTopic?: string;
+  recipientTopic?: string;
+} = {}) {
   return {
     address: testnet ? TOKENS.USDC.addresses.baseSepolia : TOKENS.USDC.addresses.base,
     data: value,
-    topics: [transferEventTopic, paymentSenderTopic, paymentRecipientTopic],
+    topics: [transferEventTopic, fromTopic, recipientTopic],
   };
 }
 
 function createSuccessfulReceipt({
+  userOpHash,
   logs = [createUsdcTransferLog()],
+  bundleLogs = logs,
   includeLogs = true,
   sender = paymentSender,
   includeSender = true,
 }: {
+  userOpHash: string;
   logs?: ReturnType<typeof createUsdcTransferLog>[];
+  bundleLogs?: ReturnType<typeof createUsdcTransferLog>[];
   includeLogs?: boolean;
   sender?: string;
   includeSender?: boolean;
-} = {}) {
+}) {
   return {
     jsonrpc: '2.0',
     id: 1,
     result: {
+      userOpHash,
       success: true,
+      ...(includeLogs ? { logs } : {}),
       receipt: {
         transactionHash: '0xabc123',
-        ...(includeLogs ? { logs } : {}),
+        logs: bundleLogs,
       },
       ...(includeSender ? { sender } : {}),
     },
@@ -72,28 +85,7 @@ describe('getPaymentStatus', () => {
   });
 
   it('should return completed status for successful payment from sender wallet', async () => {
-    const mockReceipt = {
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        success: true,
-        receipt: {
-          transactionHash: '0xabc123',
-          logs: [
-            {
-              address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-              data: '0x0000000000000000000000000000000000000000000000000000000000989680', // 10 USDC (10 * 10^6)
-              topics: [
-                '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef', // Transfer event topic
-                '0x0000000000000000000000004a7c6899cdcb379e284fbfd045462e751da4c7ce', // from address (padded) - matches sender
-                '0x000000000000000000000000f1ddf1fc0310cb11f0ca87508207012f4a9cb336', // to address (padded)
-              ],
-            },
-          ],
-        },
-        sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
-      },
-    };
+    const mockReceipt = createSuccessfulReceipt({ userOpHash: '0x123456' });
 
     vi.mocked(fetch).mockResolvedValueOnce({
       json: async () => mockReceipt,
@@ -130,7 +122,7 @@ describe('getPaymentStatus', () => {
 
   it('should return completed status when expected payment details match', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
-      json: async () => createSuccessfulReceipt(),
+      json: async () => createSuccessfulReceipt({ userOpHash: '0xexpected-payment' }),
     } as Response);
 
     const status = await getPaymentStatus({
@@ -149,7 +141,7 @@ describe('getPaymentStatus', () => {
 
   it('should reject a payment whose amount does not match the expected amount', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
-      json: async () => createSuccessfulReceipt(),
+      json: async () => createSuccessfulReceipt({ userOpHash: '0xwrong-amount' }),
     } as Response);
 
     await expect(
@@ -176,7 +168,7 @@ describe('getPaymentStatus', () => {
 
   it('should reject a payment whose recipient does not match the expected recipient', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
-      json: async () => createSuccessfulReceipt(),
+      json: async () => createSuccessfulReceipt({ userOpHash: '0xwrong-recipient' }),
     } as Response);
 
     await expect(
@@ -195,7 +187,7 @@ describe('getPaymentStatus', () => {
 
   it('should reject an invalid expected amount', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
-      json: async () => createSuccessfulReceipt(),
+      json: async () => createSuccessfulReceipt({ userOpHash: '0xinvalid-amount' }),
     } as Response);
 
     await expect(
@@ -210,9 +202,43 @@ describe('getPaymentStatus', () => {
     ).rejects.toThrow('Unable to verify payment: expected USDC amount is invalid.');
   });
 
+  it('should reject an expected amount with more than six decimal places', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt({ userOpHash: '0xexcess-precision' }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xexcess-precision',
+        expectedPayment: {
+          amount: '10.0000004',
+          recipient: '0xf1ddf1fc0310cb11f0ca87508207012f4a9cb336',
+        },
+        testnet: false,
+      })
+    ).rejects.toThrow('Unable to verify payment: expected USDC amount is invalid.');
+  });
+
+  it('should reject a non-positive expected amount', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt({ userOpHash: '0xzero-expected-amount' }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xzero-expected-amount',
+        expectedPayment: {
+          amount: '0',
+          recipient: '0xf1ddf1fc0310cb11f0ca87508207012f4a9cb336',
+        },
+        testnet: false,
+      })
+    ).rejects.toThrow('Unable to verify payment: expected USDC amount is invalid.');
+  });
+
   it('should reject an invalid expected recipient', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
-      json: async () => createSuccessfulReceipt(),
+      json: async () => createSuccessfulReceipt({ userOpHash: '0xinvalid-recipient' }),
     } as Response);
 
     await expect(
@@ -227,11 +253,43 @@ describe('getPaymentStatus', () => {
     ).rejects.toThrow('Unable to verify payment: expected recipient address is invalid.');
   });
 
+  it('should reject malformed expected payment details from untyped callers', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt({ userOpHash: '0xmalformed-expected-payment' }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xmalformed-expected-payment',
+        expectedPayment: {
+          amount: 10,
+          recipient: '0xf1ddf1fc0310cb11f0ca87508207012f4a9cb336',
+        } as unknown as NonNullable<PaymentStatusOptions['expectedPayment']>,
+        testnet: false,
+      })
+    ).rejects.toThrow('Unable to verify payment: expected payment details are invalid.');
+  });
+
+  it('should reject a null expected payment from untyped callers', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt({ userOpHash: '0xnull-expected-payment' }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xnull-expected-payment',
+        expectedPayment: null as unknown as NonNullable<PaymentStatusOptions['expectedPayment']>,
+        testnet: false,
+      })
+    ).rejects.toThrow('Unable to verify payment: expected payment details are invalid.');
+  });
+
   it('should return failed status for failed payment', async () => {
     const mockReceipt = {
       jsonrpc: '2.0',
       id: 1,
       result: {
+        userOpHash: '0x789abc',
         success: false,
         receipt: {
           transactionHash: '0xdef456',
@@ -247,6 +305,10 @@ describe('getPaymentStatus', () => {
 
     const status = await getPaymentStatus({
       id: '0x789abc',
+      expectedPayment: {
+        amount: '10',
+        recipient: '0xf1ddf1fc0310cb11f0ca87508207012f4a9cb336',
+      },
       testnet: false,
     });
 
@@ -332,6 +394,52 @@ describe('getPaymentStatus', () => {
         testnet: false,
       })
     ).rejects.toThrow('RPC error: Invalid params');
+
+    const { logPaymentStatusCheckCompleted, logPaymentStatusCheckError } = await import(
+      ':core/telemetry/events/payment.js'
+    );
+    expect(logPaymentStatusCheckCompleted).not.toHaveBeenCalled();
+    expect(logPaymentStatusCheckError).toHaveBeenCalledTimes(1);
+    expect(logPaymentStatusCheckError).toHaveBeenCalledWith({
+      testnet: false,
+      correlationId: 'mock-correlation-id',
+      errorMessage: 'RPC error: Invalid params',
+    });
+  });
+
+  it('should reject RPC errors from the pending user operation lookup', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        json: async () => ({ jsonrpc: '2.0', id: 1, result: null }),
+      } as Response)
+      .mockResolvedValueOnce({
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: 2,
+          error: {
+            code: -32000,
+            message: 'Bundler unavailable',
+          },
+        }),
+      } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xpending-rpc-error',
+        testnet: false,
+      })
+    ).rejects.toThrow('RPC error: Bundler unavailable');
+
+    const { logPaymentStatusCheckCompleted, logPaymentStatusCheckError } = await import(
+      ':core/telemetry/events/payment.js'
+    );
+    expect(logPaymentStatusCheckCompleted).not.toHaveBeenCalled();
+    expect(logPaymentStatusCheckError).toHaveBeenCalledTimes(1);
+    expect(logPaymentStatusCheckError).toHaveBeenCalledWith({
+      testnet: false,
+      correlationId: 'mock-correlation-id',
+      errorMessage: 'RPC error: Bundler unavailable',
+    });
   });
 
   it('should handle network errors gracefully', async () => {
@@ -379,6 +487,7 @@ describe('getPaymentStatus', () => {
           jsonrpc: '2.0',
           id: 1,
           result: {
+            userOpHash: '0xfailedreason',
             success: false,
             receipt: { transactionHash: '0xfailed' },
             sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
@@ -397,28 +506,10 @@ describe('getPaymentStatus', () => {
   });
 
   it('should handle logs with different USDC addresses on testnet', async () => {
-    const mockReceipt = {
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        success: true,
-        receipt: {
-          transactionHash: '0xabc123',
-          logs: [
-            {
-              address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e', // testnet USDC
-              data: '0x0000000000000000000000000000000000000000000000000000000000989680', // 10 USDC
-              topics: [
-                '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
-                '0x0000000000000000000000004a7c6899cdcb379e284fbfd045462e751da4c7ce', // from address (padded) - matches sender
-                '0x000000000000000000000000f1ddf1fc0310cb11f0ca87508207012f4a9cb336', // to address (padded)
-              ],
-            },
-          ],
-        },
-        sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
-      },
-    };
+    const mockReceipt = createSuccessfulReceipt({
+      userOpHash: '0x123456',
+      logs: [createUsdcTransferLog({ testnet: true })],
+    });
 
     vi.mocked(fetch).mockResolvedValueOnce({
       json: async () => mockReceipt,
@@ -435,7 +526,7 @@ describe('getPaymentStatus', () => {
 
   it('should reject a successful user operation with no USDC transfers', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
-      json: async () => createSuccessfulReceipt({ logs: [] }),
+      json: async () => createSuccessfulReceipt({ userOpHash: '0xno-payment', logs: [] }),
     } as Response);
 
     await expect(
@@ -456,9 +547,65 @@ describe('getPaymentStatus', () => {
     });
   });
 
-  it('should reject a successful user operation when receipt logs are missing', async () => {
+  it('should ignore matching transfers from other user operations in the same bundle', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
-      json: async () => createSuccessfulReceipt({ includeLogs: false }),
+      json: async () =>
+        createSuccessfulReceipt({
+          userOpHash: '0xbundled-noop',
+          logs: [],
+          bundleLogs: [createUsdcTransferLog()],
+        }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xbundled-noop',
+        testnet: false,
+      })
+    ).rejects.toThrow(/Unable to find USDC transfer from sender wallet.*Found 0 USDC transfer/);
+  });
+
+  it('should reject a receipt for a different user operation hash', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt({ userOpHash: '0xdifferent-operation' }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xrequested-operation',
+        testnet: false,
+      })
+    ).rejects.toThrow(
+      'Unable to verify payment: receipt does not match the requested transaction.'
+    );
+  });
+
+  it('should reject a receipt with no user operation hash', async () => {
+    const mockReceipt = createSuccessfulReceipt({ userOpHash: '0xrequested-operation' });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => ({
+        ...mockReceipt,
+        result: {
+          ...mockReceipt.result,
+          userOpHash: undefined,
+        },
+      }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xrequested-operation',
+        testnet: false,
+      })
+    ).rejects.toThrow(
+      'Unable to verify payment: receipt does not match the requested transaction.'
+    );
+  });
+
+  it('should reject a successful user operation when scoped logs are missing', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () =>
+        createSuccessfulReceipt({ userOpHash: '0xmissing-logs', includeLogs: false }),
     } as Response);
 
     await expect(
@@ -466,12 +613,13 @@ describe('getPaymentStatus', () => {
         id: '0xmissing-logs',
         testnet: false,
       })
-    ).rejects.toThrow('Unable to verify payment: transaction receipt is missing logs.');
+    ).rejects.toThrow('Unable to verify payment: user operation receipt is missing logs.');
   });
 
   it('should reject a successful user operation when the sender is missing', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
-      json: async () => createSuccessfulReceipt({ includeSender: false }),
+      json: async () =>
+        createSuccessfulReceipt({ userOpHash: '0xmissing-sender', includeSender: false }),
     } as Response);
 
     await expect(
@@ -486,6 +634,7 @@ describe('getPaymentStatus', () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       json: async () =>
         createSuccessfulReceipt({
+          userOpHash: '0xzero-value',
           logs: [
             createUsdcTransferLog({
               value: '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -506,6 +655,7 @@ describe('getPaymentStatus', () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       json: async () =>
         createSuccessfulReceipt({
+          userOpHash: '0xmalformed-transfer',
           logs: [createUsdcTransferLog({ value: '0x' })],
         }),
     } as Response);
@@ -519,29 +669,14 @@ describe('getPaymentStatus', () => {
   });
 
   it('should throw error when no USDC transfer from sender wallet is found', async () => {
-    const mockReceipt = {
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        success: true,
-        receipt: {
-          transactionHash: '0xabc123',
-          logs: [
-            {
-              // USDC transfer but not from sender
-              address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-              data: '0x0000000000000000000000000000000000000000000000000000000000989680',
-              topics: [
-                '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
-                '0x000000000000000000000000bbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb', // from different address
-                '0x000000000000000000000000f1ddf1fc0310cb11f0ca87508207012f4a9cb336',
-              ],
-            },
-          ],
-        },
-        sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
-      },
-    };
+    const mockReceipt = createSuccessfulReceipt({
+      userOpHash: '0x123456',
+      logs: [
+        createUsdcTransferLog({
+          fromTopic: '0x000000000000000000000000bbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb',
+        }),
+      ],
+    });
 
     vi.mocked(fetch).mockResolvedValueOnce({
       json: async () => mockReceipt,
@@ -558,37 +693,16 @@ describe('getPaymentStatus', () => {
   });
 
   it('should throw error when multiple USDC transfers from sender wallet are found', async () => {
-    const mockReceipt = {
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        success: true,
-        receipt: {
-          transactionHash: '0xabc123',
-          logs: [
-            {
-              address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-              data: '0x0000000000000000000000000000000000000000000000000000000000989680', // 10 USDC
-              topics: [
-                '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
-                '0x0000000000000000000000004a7c6899cdcb379e284fbfd045462e751da4c7ce', // from sender
-                '0x000000000000000000000000f1ddf1fc0310cb11f0ca87508207012f4a9cb336',
-              ],
-            },
-            {
-              address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-              data: '0x00000000000000000000000000000000000000000000000000000000000f4240', // 1 USDC
-              topics: [
-                '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
-                '0x0000000000000000000000004a7c6899cdcb379e284fbfd045462e751da4c7ce', // from sender
-                '0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-              ],
-            },
-          ],
-        },
-        sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
-      },
-    };
+    const mockReceipt = createSuccessfulReceipt({
+      userOpHash: '0x123456',
+      logs: [
+        createUsdcTransferLog(),
+        createUsdcTransferLog({
+          value: '0x00000000000000000000000000000000000000000000000000000000000f4240',
+          recipientTopic: '0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        }),
+      ],
+    });
 
     vi.mocked(fetch).mockResolvedValueOnce({
       json: async () => mockReceipt,
@@ -605,39 +719,19 @@ describe('getPaymentStatus', () => {
   });
 
   it('should correctly identify transfer from sender in complex transaction with multiple USDC transfers', async () => {
-    const mockReceipt = {
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        success: true,
-        receipt: {
-          transactionHash: '0xabc123',
-          logs: [
-            {
-              // Gas payment transfer (not from sender)
-              address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-              data: '0x00000000000000000000000000000000000000000000000000000010c388d00', // 4500 USDC
-              topics: [
-                '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
-                '0x000000000000000000000000bbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb',
-                '0x000000000000000000000000cccccccccccccccccccccccccccccccccccccccc',
-              ],
-            },
-            {
-              // Actual user payment (from sender)
-              address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-              data: '0x00000000000000000000000000000000000000000000000000000000000f4240', // 1 USDC
-              topics: [
-                '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
-                '0x0000000000000000000000004a7c6899cdcb379e284fbfd045462e751da4c7ce',
-                '0x000000000000000000000000f1ddf1fc0310cb11f0ca87508207012f4a9cb336',
-              ],
-            },
-          ],
-        },
-        sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
-      },
-    };
+    const mockReceipt = createSuccessfulReceipt({
+      userOpHash: '0x123456',
+      logs: [
+        createUsdcTransferLog({
+          value: '0x00000000000000000000000000000000000000000000000000000010c388d00',
+          fromTopic: '0x000000000000000000000000bbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb',
+          recipientTopic: '0x000000000000000000000000cccccccccccccccccccccccccccccccccccccccc',
+        }),
+        createUsdcTransferLog({
+          value: '0x00000000000000000000000000000000000000000000000000000000000f4240',
+        }),
+      ],
+    });
 
     vi.mocked(fetch).mockResolvedValueOnce({
       json: async () => mockReceipt,
@@ -660,18 +754,7 @@ describe('getPaymentStatus', () => {
 
   describe('telemetry', () => {
     it('should not log telemetry when telemetry is disabled', async () => {
-      const mockReceipt = {
-        jsonrpc: '2.0',
-        id: 1,
-        result: {
-          success: true,
-          receipt: {
-            transactionHash: '0xabc123',
-            logs: [createUsdcTransferLog()],
-          },
-          sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
-        },
-      };
+      const mockReceipt = createSuccessfulReceipt({ userOpHash: '0x123456' });
 
       vi.mocked(fetch).mockResolvedValueOnce({
         json: async () => mockReceipt,
@@ -695,18 +778,7 @@ describe('getPaymentStatus', () => {
     });
 
     it('should log telemetry by default when telemetry is not specified', async () => {
-      const mockReceipt = {
-        jsonrpc: '2.0',
-        id: 1,
-        result: {
-          success: true,
-          receipt: {
-            transactionHash: '0xabc123',
-            logs: [createUsdcTransferLog()],
-          },
-          sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
-        },
-      };
+      const mockReceipt = createSuccessfulReceipt({ userOpHash: '0x123456' });
 
       vi.mocked(fetch).mockResolvedValueOnce({
         json: async () => mockReceipt,
@@ -801,28 +873,7 @@ describe('getPaymentStatus', () => {
   describe('custom bundlerUrl', () => {
     it('should use custom bundler URL when provided', async () => {
       const customBundlerUrl = 'https://my-custom-bundler.example.com/rpc';
-      const mockReceipt = {
-        jsonrpc: '2.0',
-        id: 1,
-        result: {
-          success: true,
-          receipt: {
-            transactionHash: '0xabc123',
-            logs: [
-              {
-                address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-                data: '0x0000000000000000000000000000000000000000000000000000000000989680',
-                topics: [
-                  '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
-                  '0x0000000000000000000000004a7c6899cdcb379e284fbfd045462e751da4c7ce',
-                  '0x000000000000000000000000f1ddf1fc0310cb11f0ca87508207012f4a9cb336',
-                ],
-              },
-            ],
-          },
-          sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
-        },
-      };
+      const mockReceipt = createSuccessfulReceipt({ userOpHash: '0x123456' });
 
       vi.mocked(fetch).mockResolvedValueOnce({
         json: async () => mockReceipt,
@@ -907,18 +958,10 @@ describe('getPaymentStatus', () => {
     });
 
     it('should fallback to default bundler URL when custom URL is not provided', async () => {
-      const mockReceipt = {
-        jsonrpc: '2.0',
-        id: 1,
-        result: {
-          success: true,
-          receipt: {
-            transactionHash: '0xabc123',
-            logs: [createUsdcTransferLog({ testnet: true })],
-          },
-          sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
-        },
-      };
+      const mockReceipt = createSuccessfulReceipt({
+        userOpHash: '0x123456',
+        logs: [createUsdcTransferLog({ testnet: true })],
+      });
 
       vi.mocked(fetch).mockResolvedValueOnce({
         json: async () => mockReceipt,

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { DEFAULT_BUNDLER_HEADERS, DEFAULT_BUNDLER_URLS } from './constants.js';
+import { DEFAULT_BUNDLER_HEADERS, DEFAULT_BUNDLER_URLS, TOKENS } from './constants.js';
 import { getPaymentStatus } from './getPaymentStatus.js';
 import type { PaymentStatus } from './types.js';
 
@@ -17,6 +17,47 @@ const defaultBundlerHeaders = {
   'Content-Type': 'application/json',
   ...DEFAULT_BUNDLER_HEADERS,
 };
+
+const paymentSender = '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce';
+const transferEventTopic = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+const paymentSenderTopic = '0x0000000000000000000000004a7c6899cdcb379e284fbfd045462e751da4c7ce';
+const paymentRecipientTopic = '0x000000000000000000000000f1ddf1fc0310cb11f0ca87508207012f4a9cb336';
+
+function createUsdcTransferLog({
+  testnet = false,
+  value = '0x0000000000000000000000000000000000000000000000000000000000989680',
+}: { testnet?: boolean; value?: string } = {}) {
+  return {
+    address: testnet ? TOKENS.USDC.addresses.baseSepolia : TOKENS.USDC.addresses.base,
+    data: value,
+    topics: [transferEventTopic, paymentSenderTopic, paymentRecipientTopic],
+  };
+}
+
+function createSuccessfulReceipt({
+  logs = [createUsdcTransferLog()],
+  includeLogs = true,
+  sender = paymentSender,
+  includeSender = true,
+}: {
+  logs?: ReturnType<typeof createUsdcTransferLog>[];
+  includeLogs?: boolean;
+  sender?: string;
+  includeSender?: boolean;
+} = {}) {
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      success: true,
+      receipt: {
+        transactionHash: '0xabc123',
+        ...(includeLogs ? { logs } : {}),
+      },
+      ...(includeSender ? { sender } : {}),
+    },
+  };
+}
 
 describe('getPaymentStatus', () => {
   beforeEach(() => {
@@ -293,6 +334,91 @@ describe('getPaymentStatus', () => {
     expect(status.recipient).toBe('0xf1DdF1fc0310Cb11F0Ca87508207012F4a9CB336');
   });
 
+  it('should reject a successful user operation with no USDC transfers', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt({ logs: [] }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xno-payment',
+        testnet: false,
+      })
+    ).rejects.toThrow(/Unable to find USDC transfer from sender wallet.*Found 0 USDC transfer/);
+
+    const { logPaymentStatusCheckCompleted, logPaymentStatusCheckError } = await import(
+      ':core/telemetry/events/payment.js'
+    );
+    expect(logPaymentStatusCheckCompleted).not.toHaveBeenCalled();
+    expect(logPaymentStatusCheckError).toHaveBeenCalledWith({
+      testnet: false,
+      correlationId: 'mock-correlation-id',
+      errorMessage: expect.stringContaining('Unable to find USDC transfer'),
+    });
+  });
+
+  it('should reject a successful user operation when receipt logs are missing', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt({ includeLogs: false }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xmissing-logs',
+        testnet: false,
+      })
+    ).rejects.toThrow('Unable to verify payment: transaction receipt is missing logs.');
+  });
+
+  it('should reject a successful user operation when the sender is missing', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt({ includeSender: false }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xmissing-sender',
+        testnet: false,
+      })
+    ).rejects.toThrow('Unable to verify payment: receipt is missing a valid sender address.');
+  });
+
+  it('should reject a zero-value USDC transfer from the sender', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () =>
+        createSuccessfulReceipt({
+          logs: [
+            createUsdcTransferLog({
+              value: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            }),
+          ],
+        }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xzero-value',
+        testnet: false,
+      })
+    ).rejects.toThrow('Unable to verify payment: USDC transfer amount must be greater than zero.');
+  });
+
+  it('should reject a successful user operation with a malformed USDC transfer log', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () =>
+        createSuccessfulReceipt({
+          logs: [createUsdcTransferLog({ value: '0x' })],
+        }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xmalformed-transfer',
+        testnet: false,
+      })
+    ).rejects.toThrow(/Unable to find USDC transfer from sender wallet.*Found 0 USDC transfer/);
+  });
+
   it('should throw error when no USDC transfer from sender wallet is found', async () => {
     const mockReceipt = {
       jsonrpc: '2.0',
@@ -442,7 +568,7 @@ describe('getPaymentStatus', () => {
           success: true,
           receipt: {
             transactionHash: '0xabc123',
-            logs: [],
+            logs: [createUsdcTransferLog()],
           },
           sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
         },
@@ -477,7 +603,7 @@ describe('getPaymentStatus', () => {
           success: true,
           receipt: {
             transactionHash: '0xabc123',
-            logs: [],
+            logs: [createUsdcTransferLog()],
           },
           sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
         },
@@ -689,7 +815,7 @@ describe('getPaymentStatus', () => {
           success: true,
           receipt: {
             transactionHash: '0xabc123',
-            logs: [],
+            logs: [createUsdcTransferLog({ testnet: true })],
           },
           sender: '0x4A7c6899cdcB379e284fBFd045462e751da4C7ce',
         },

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
@@ -128,6 +128,105 @@ describe('getPaymentStatus', () => {
     );
   });
 
+  it('should return completed status when expected payment details match', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt(),
+    } as Response);
+
+    const status = await getPaymentStatus({
+      id: '0xexpected-payment',
+      expectedPayment: {
+        amount: '10.000000',
+        recipient: '0xf1ddf1fc0310cb11f0ca87508207012f4a9cb336',
+      },
+      testnet: false,
+    });
+
+    expect(status.status).toBe('completed');
+    expect(status.amount).toBe('10');
+    expect(status.recipient).toBe('0xf1DdF1fc0310Cb11F0Ca87508207012F4a9CB336');
+  });
+
+  it('should reject a payment whose amount does not match the expected amount', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt(),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xwrong-amount',
+        expectedPayment: {
+          amount: '9.99',
+          recipient: '0xf1ddf1fc0310cb11f0ca87508207012f4a9cb336',
+        },
+        testnet: false,
+      })
+    ).rejects.toThrow('Unable to verify payment: USDC amount does not match the expected amount.');
+
+    const { logPaymentStatusCheckCompleted, logPaymentStatusCheckError } = await import(
+      ':core/telemetry/events/payment.js'
+    );
+    expect(logPaymentStatusCheckCompleted).not.toHaveBeenCalled();
+    expect(logPaymentStatusCheckError).toHaveBeenCalledWith({
+      testnet: false,
+      correlationId: 'mock-correlation-id',
+      errorMessage: 'Unable to verify payment: USDC amount does not match the expected amount.',
+    });
+  });
+
+  it('should reject a payment whose recipient does not match the expected recipient', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt(),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xwrong-recipient',
+        expectedPayment: {
+          amount: '10',
+          recipient: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        },
+        testnet: false,
+      })
+    ).rejects.toThrow(
+      'Unable to verify payment: USDC recipient does not match the expected recipient.'
+    );
+  });
+
+  it('should reject an invalid expected amount', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt(),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xinvalid-amount',
+        expectedPayment: {
+          amount: 'not-an-amount',
+          recipient: '0xf1ddf1fc0310cb11f0ca87508207012f4a9cb336',
+        },
+        testnet: false,
+      })
+    ).rejects.toThrow('Unable to verify payment: expected USDC amount is invalid.');
+  });
+
+  it('should reject an invalid expected recipient', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => createSuccessfulReceipt(),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xinvalid-recipient',
+        expectedPayment: {
+          amount: '10',
+          recipient: '0xinvalid',
+        },
+        testnet: false,
+      })
+    ).rejects.toThrow('Unable to verify payment: expected recipient address is invalid.');
+  });
+
   it('should return failed status for failed payment', async () => {
     const mockReceipt = {
       jsonrpc: '2.0',

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
@@ -478,6 +478,23 @@ describe('getPaymentStatus', () => {
     expect(logPaymentStatusCheckError).toHaveBeenCalledTimes(1);
   });
 
+  it('should reject unsuccessful HTTP responses from fetch polyfills without ok', async () => {
+    const json = vi.fn();
+    vi.mocked(fetch).mockResolvedValueOnce({
+      status: 503,
+      json,
+    } as unknown as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xpolyfill-http-error',
+        testnet: false,
+      })
+    ).rejects.toThrow('RPC request failed with HTTP status 503');
+
+    expect(json).not.toHaveBeenCalled();
+  });
+
   it('should reject a malformed receipt response without a result', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
@@ -333,7 +333,7 @@ describe('getPaymentStatus', () => {
         jsonrpc: '2.0',
         id: 2,
         result: {
-          sender: '0xpendingSender',
+          sender: paymentSender,
           // other userOp fields...
         },
       }),
@@ -348,7 +348,7 @@ describe('getPaymentStatus', () => {
       status: 'pending',
       id: '0xpending123',
       message: 'Your payment is being processed. This usually takes a few seconds.',
-      sender: '0xpendingSender',
+      sender: paymentSender,
     });
 
     expect(fetch).toHaveBeenCalledTimes(2);
@@ -529,6 +529,46 @@ describe('getPaymentStatus', () => {
     await expect(
       getPaymentStatus({
         id: '0xscalar-pending-result',
+        testnet: false,
+      })
+    ).rejects.toThrow('RPC error: Invalid response');
+
+    const { logPaymentStatusCheckCompleted } = await import(':core/telemetry/events/payment.js');
+    expect(logPaymentStatusCheckCompleted).not.toHaveBeenCalled();
+  });
+
+  it('should reject a receipt result without a boolean success field', async () => {
+    const mockReceipt = createSuccessfulReceipt({ userOpHash: '0xmissing-success' });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: async () => ({
+        ...mockReceipt,
+        result: {
+          ...mockReceipt.result,
+          success: undefined,
+        },
+      }),
+    } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xmissing-success',
+        testnet: false,
+      })
+    ).rejects.toThrow('RPC error: Invalid response');
+  });
+
+  it('should reject a pending lookup result without a sender', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        json: async () => ({ jsonrpc: '2.0', id: 1, result: null }),
+      } as Response)
+      .mockResolvedValueOnce({
+        json: async () => ({ jsonrpc: '2.0', id: 2, result: {} }),
+      } as Response);
+
+    await expect(
+      getPaymentStatus({
+        id: '0xmissing-pending-sender',
         testnet: false,
       })
     ).rejects.toThrow('RPC error: Invalid response');

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.test.ts
@@ -75,6 +75,7 @@ function createSuccessfulReceipt({
 describe('getPaymentStatus', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fetch).mockReset();
     // Mock console methods to avoid noise in tests
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -200,6 +201,7 @@ describe('getPaymentStatus', () => {
         testnet: false,
       })
     ).rejects.toThrow('Unable to verify payment: expected USDC amount is invalid.');
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('should reject an expected amount with more than six decimal places', async () => {
@@ -374,6 +376,17 @@ describe('getPaymentStatus', () => {
       id: '0xnotfound',
       message: 'Payment not found. Please check your transaction ID.',
     });
+  });
+
+  it('should reject an invalid transaction ID before making an RPC request', async () => {
+    await expect(
+      getPaymentStatus({
+        id: '',
+        testnet: false,
+      })
+    ).rejects.toThrow('Unable to verify payment: transaction ID is invalid.');
+
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('should handle RPC errors gracefully', async () => {

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
@@ -160,6 +160,15 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
       }).then(readJsonRpcResponse);
 
       if (userOpResponse.result) {
+        if (typeof userOpResponse.result.sender !== 'string') {
+          throw new Error('RPC error: Invalid response');
+        }
+        try {
+          getAddress(userOpResponse.result.sender);
+        } catch {
+          throw new Error('RPC error: Invalid response');
+        }
+
         // UserOp exists but no receipt yet - it's pending
         if (telemetry) {
           logPaymentStatusCheckCompleted({ testnet, status: 'pending', correlationId });
@@ -197,6 +206,22 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
     }
 
     const { success, reason } = userOpReceipt;
+    if (typeof success !== 'boolean') {
+      throw new Error('RPC error: Invalid response');
+    }
+    if (reason !== undefined && reason !== null && typeof reason !== 'string') {
+      throw new Error('RPC error: Invalid response');
+    }
+    if (typeof userOpReceipt.sender !== 'string') {
+      throw new Error('Unable to verify payment: receipt is missing a valid sender address.');
+    }
+
+    let senderAddress: Address;
+    try {
+      senderAddress = getAddress(userOpReceipt.sender);
+    } catch {
+      throw new Error('Unable to verify payment: receipt is missing a valid sender address.');
+    }
 
     // Determine status based on success flag
     if (success === true) {
@@ -204,17 +229,6 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
       // every UserOperation in the bundle and must not be used for payment verification.
       if (!Array.isArray(userOpReceipt.logs)) {
         throw new Error('Unable to verify payment: user operation receipt is missing logs.');
-      }
-
-      if (typeof userOpReceipt.sender !== 'string') {
-        throw new Error('Unable to verify payment: receipt is missing a valid sender address.');
-      }
-
-      let senderAddress: Address;
-      try {
-        senderAddress = getAddress(userOpReceipt.sender);
-      } catch {
-        throw new Error('Unable to verify payment: receipt is missing a valid sender address.');
       }
 
       const network = testnet ? 'baseSepolia' : 'base';

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
@@ -63,6 +63,11 @@ async function readJsonRpcResponse(response: Response) {
     throw new Error('RPC error: Invalid response');
   }
 
+  const result = (body as { result: unknown }).result;
+  if (result !== null && (typeof result !== 'object' || Array.isArray(result))) {
+    throw new Error('RPC error: Invalid response');
+  }
+
   return body;
 }
 

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
@@ -48,6 +48,24 @@ function getRpcErrorMessage(response: unknown): string | undefined {
   return 'Network error';
 }
 
+async function readJsonRpcResponse(response: Response) {
+  if (response.ok === false) {
+    throw new Error(`RPC request failed with HTTP status ${response.status}`);
+  }
+
+  const body = await response.json();
+  const rpcErrorMessage = getRpcErrorMessage(body);
+  if (rpcErrorMessage) {
+    throw new Error(`RPC error: ${rpcErrorMessage}`);
+  }
+
+  if (!body || typeof body !== 'object' || !('result' in body)) {
+    throw new Error('RPC error: Invalid response');
+  }
+
+  return body;
+}
+
 /**
  * Check the status of a payment transaction using its transaction ID (userOp hash)
  *
@@ -120,12 +138,7 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
         method: 'eth_getUserOperationReceipt',
         params: [id],
       }),
-    }).then((res) => res.json());
-
-    const receiptErrorMessage = getRpcErrorMessage(receipt);
-    if (receiptErrorMessage) {
-      throw new Error(`RPC error: ${receiptErrorMessage}`);
-    }
+    }).then(readJsonRpcResponse);
 
     // If no result, payment is still pending or not found
     if (!receipt.result) {
@@ -139,12 +152,7 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
           method: 'eth_getUserOperationByHash',
           params: [id],
         }),
-      }).then((res) => res.json());
-
-      const userOpErrorMessage = getRpcErrorMessage(userOpResponse);
-      if (userOpErrorMessage) {
-        throw new Error(`RPC error: ${userOpErrorMessage}`);
-      }
+      }).then(readJsonRpcResponse);
 
       if (userOpResponse.result) {
         // UserOp exists but no receipt yet - it's pending

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
@@ -1,5 +1,5 @@
 import type { Address, Hex } from 'viem';
-import { decodeEventLog, formatUnits, getAddress, isAddressEqual } from 'viem';
+import { decodeEventLog, formatUnits, getAddress, isAddressEqual, parseUnits } from 'viem';
 
 import {
   logPaymentStatusCheckCompleted,
@@ -30,18 +30,23 @@ function getBundlerRequestHeaders(usingDefaultBundlerUrl: boolean): Record<strin
  *
  * @param options - Payment status check options
  * @param options.id - Transaction ID (userOp hash) to check status for
+ * @param options.expectedPayment - Optional trusted amount and recipient to verify
  * @param options.testnet - Whether to check on testnet (Base Sepolia). Defaults to false (mainnet)
  * @param options.telemetry - Whether to enable telemetry logging. Defaults to true
  * @param options.bundlerUrl - Optional custom bundler URL to use for status checks. Useful for avoiding rate limits on public endpoints.
  * @returns Promise<PaymentStatus> - Status information about the payment
- * @throws Error if the RPC request fails or the receipt does not contain exactly one positive
- * sender-origin USDC transfer
+ * @throws Error if the RPC request fails, the receipt does not contain exactly one positive
+ * sender-origin USDC transfer, or the transfer does not match the expected payment
  *
  * @example
  * ```typescript
  * try {
  *   const status = await getPaymentStatus({
  *     id: "0x1234...5678",
+ *     expectedPayment: {
+ *       amount: "10.50",
+ *       recipient: "0xFe21034794A5a574B94fE4fDfD16e005F1C96e51"
+ *     },
  *     testnet: true
  *   })
  *
@@ -63,7 +68,7 @@ function getBundlerRequestHeaders(usingDefaultBundlerUrl: boolean): Record<strin
  * @note The id is the userOp hash returned from the pay function
  */
 export async function getPaymentStatus(options: PaymentStatusOptions): Promise<PaymentStatus> {
-  const { id, testnet = false, telemetry = true, bundlerUrl } = options;
+  const { id, expectedPayment, testnet = false, telemetry = true, bundlerUrl } = options;
 
   // Generate correlation ID for this status check
   const correlationId = crypto.randomUUID();
@@ -232,6 +237,47 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
         throw new Error(
           'Unable to verify payment: USDC transfer amount must be greater than zero.'
         );
+      }
+
+      if (expectedPayment !== undefined) {
+        if (
+          !expectedPayment ||
+          typeof expectedPayment.amount !== 'string' ||
+          typeof expectedPayment.recipient !== 'string'
+        ) {
+          throw new Error('Unable to verify payment: expected payment details are invalid.');
+        }
+
+        let expectedAmount: bigint;
+        try {
+          expectedAmount = parseUnits(expectedPayment.amount, TOKENS.USDC.decimals);
+        } catch {
+          throw new Error('Unable to verify payment: expected USDC amount is invalid.');
+        }
+
+        if (expectedAmount <= 0n) {
+          throw new Error(
+            'Unable to verify payment: expected USDC amount must be greater than zero.'
+          );
+        }
+        if (paymentTransfer.value !== expectedAmount) {
+          throw new Error(
+            'Unable to verify payment: USDC amount does not match the expected amount.'
+          );
+        }
+
+        let expectedRecipient: Address;
+        try {
+          expectedRecipient = getAddress(expectedPayment.recipient);
+        } catch {
+          throw new Error('Unable to verify payment: expected recipient address is invalid.');
+        }
+
+        if (!isAddressEqual(paymentTransfer.to as Address, expectedRecipient)) {
+          throw new Error(
+            'Unable to verify payment: USDC recipient does not match the expected recipient.'
+          );
+        }
       }
 
       if (telemetry) {

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
@@ -15,6 +15,15 @@ import {
 import type { PaymentStatus, PaymentStatusOptions } from './types.js';
 import { validateStringAmount } from './utils/validation.js';
 
+interface JsonRpcResponse {
+  result: Record<string, unknown> | null;
+}
+
+interface ValidatedExpectedPayment {
+  amount: bigint;
+  recipient: Address;
+}
+
 function getDefaultBundlerUrl(testnet: boolean): string {
   return testnet ? DEFAULT_BUNDLER_URLS.baseSepolia : DEFAULT_BUNDLER_URLS.base;
 }
@@ -48,7 +57,7 @@ function getRpcErrorMessage(response: unknown): string | undefined {
   return 'Network error';
 }
 
-async function readJsonRpcResponse(response: Response) {
+async function readJsonRpcResponse(response: Response): Promise<JsonRpcResponse> {
   if (response.ok === false) {
     throw new Error(`RPC request failed with HTTP status ${response.status}`);
   }
@@ -68,7 +77,7 @@ async function readJsonRpcResponse(response: Response) {
     throw new Error('RPC error: Invalid response');
   }
 
-  return body;
+  return body as JsonRpcResponse;
 }
 
 /**
@@ -129,6 +138,42 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
   }
 
   try {
+    if (typeof id !== 'string' || !id) {
+      throw new Error('Unable to verify payment: transaction ID is invalid.');
+    }
+
+    let validatedExpectedPayment: ValidatedExpectedPayment | undefined;
+    if (expectedPayment !== undefined) {
+      // Defend JavaScript callers that do not get the PaymentStatusOptions type checks.
+      if (
+        !expectedPayment ||
+        typeof expectedPayment.amount !== 'string' ||
+        typeof expectedPayment.recipient !== 'string'
+      ) {
+        throw new Error('Unable to verify payment: expected payment details are invalid.');
+      }
+
+      let expectedAmount: bigint;
+      try {
+        validateStringAmount(expectedPayment.amount, TOKENS.USDC.decimals);
+        expectedAmount = parseUnits(expectedPayment.amount, TOKENS.USDC.decimals);
+      } catch {
+        throw new Error('Unable to verify payment: expected USDC amount is invalid.');
+      }
+
+      let expectedRecipient: Address;
+      try {
+        expectedRecipient = getAddress(expectedPayment.recipient);
+      } catch {
+        throw new Error('Unable to verify payment: expected recipient address is invalid.');
+      }
+
+      validatedExpectedPayment = {
+        amount: expectedAmount,
+        recipient: expectedRecipient,
+      };
+    }
+
     const usingDefaultBundlerUrl = !bundlerUrl;
     const effectiveBundlerUrl = bundlerUrl || getDefaultBundlerUrl(testnet);
     const headers = getBundlerRequestHeaders(usingDefaultBundlerUrl);
@@ -196,7 +241,6 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
 
     const userOpReceipt = receipt.result;
     if (
-      typeof id !== 'string' ||
       typeof userOpReceipt.userOpHash !== 'string' ||
       userOpReceipt.userOpHash.toLowerCase() !== id.toLowerCase()
     ) {
@@ -236,8 +280,8 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
 
       // Collect all USDC transfers
       const usdcTransfers: Array<{
-        from: string;
-        to: string;
+        from: Address;
+        to: Address;
         value: bigint;
         formattedAmount: string;
       }> = [];
@@ -255,17 +299,14 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
               topics: log.topics,
             });
 
-            if (decoded.eventName === 'Transfer' && decoded.args) {
-              const args = decoded.args as { from: string; to: string; value: bigint };
-
-              if (typeof args.value === 'bigint' && args.to && args.from) {
-                usdcTransfers.push({
-                  from: args.from,
-                  to: args.to,
-                  value: args.value,
-                  formattedAmount: formatUnits(args.value, TOKENS.USDC.decimals),
-                });
-              }
+            if (decoded.eventName === 'Transfer') {
+              const { from, to, value } = decoded.args;
+              usdcTransfers.push({
+                from,
+                to,
+                value,
+                formattedAmount: formatUnits(value, TOKENS.USDC.decimals),
+              });
             }
           } catch (_e) {
             // Do not fail here - fail when we can't find a single valid transfer
@@ -276,7 +317,7 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
       // Find the payment transfer from the sender (smart wallet) address.
       const senderTransfers = usdcTransfers.filter((transfer) => {
         try {
-          return isAddressEqual(transfer.from as Address, senderAddress);
+          return isAddressEqual(transfer.from, senderAddress);
         } catch {
           return false;
         }
@@ -304,38 +345,14 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
         );
       }
 
-      if (expectedPayment !== undefined) {
-        // Defend JavaScript callers that do not get the PaymentStatusOptions type checks.
-        if (
-          !expectedPayment ||
-          typeof expectedPayment.amount !== 'string' ||
-          typeof expectedPayment.recipient !== 'string'
-        ) {
-          throw new Error('Unable to verify payment: expected payment details are invalid.');
-        }
-
-        let expectedAmount: bigint;
-        try {
-          validateStringAmount(expectedPayment.amount, TOKENS.USDC.decimals);
-          expectedAmount = parseUnits(expectedPayment.amount, TOKENS.USDC.decimals);
-        } catch {
-          throw new Error('Unable to verify payment: expected USDC amount is invalid.');
-        }
-
-        if (paymentTransfer.value !== expectedAmount) {
+      if (validatedExpectedPayment) {
+        if (paymentTransfer.value !== validatedExpectedPayment.amount) {
           throw new Error(
             'Unable to verify payment: USDC amount does not match the expected amount.'
           );
         }
 
-        let expectedRecipient: Address;
-        try {
-          expectedRecipient = getAddress(expectedPayment.recipient);
-        } catch {
-          throw new Error('Unable to verify payment: expected recipient address is invalid.');
-        }
-
-        if (!isAddressEqual(paymentTransfer.to as Address, expectedRecipient)) {
+        if (!isAddressEqual(paymentTransfer.to, validatedExpectedPayment.recipient)) {
           throw new Error(
             'Unable to verify payment: USDC recipient does not match the expected recipient.'
           );

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
@@ -34,7 +34,8 @@ function getBundlerRequestHeaders(usingDefaultBundlerUrl: boolean): Record<strin
  * @param options.telemetry - Whether to enable telemetry logging. Defaults to true
  * @param options.bundlerUrl - Optional custom bundler URL to use for status checks. Useful for avoiding rate limits on public endpoints.
  * @returns Promise<PaymentStatus> - Status information about the payment
- * @throws Error if unable to connect to the RPC endpoint or if the RPC request fails
+ * @throws Error if the RPC request fails or the receipt does not contain exactly one positive
+ * sender-origin USDC transfer
  *
  * @example
  * ```typescript
@@ -144,97 +145,93 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
     const { success, receipt: txReceipt, reason } = receipt.result;
 
     // Determine status based on success flag
-    if (success) {
-      // Parse USDC amount from logs
-      let amount: string | undefined;
-      let recipient: string | undefined;
+    if (success === true) {
+      if (!Array.isArray(txReceipt?.logs)) {
+        throw new Error('Unable to verify payment: transaction receipt is missing logs.');
+      }
 
-      if (txReceipt?.logs) {
-        const network = testnet ? 'baseSepolia' : 'base';
-        const usdcAddress = TOKENS.USDC.addresses[network].toLowerCase();
-        // Normalize sender address for comparison
-        const senderAddress: Address | undefined = receipt.result.sender
-          ? getAddress(receipt.result.sender)
-          : undefined;
+      if (typeof receipt.result.sender !== 'string') {
+        throw new Error('Unable to verify payment: receipt is missing a valid sender address.');
+      }
 
-        // Collect all USDC transfers
-        const usdcTransfers: Array<{
-          from: string;
-          to: string;
-          value: bigint;
-          formattedAmount: string;
-          logIndex: number;
-        }> = [];
+      let senderAddress: Address;
+      try {
+        senderAddress = getAddress(receipt.result.sender);
+      } catch {
+        throw new Error('Unable to verify payment: receipt is missing a valid sender address.');
+      }
 
-        for (let i = 0; i < txReceipt.logs.length; i++) {
-          const log = txReceipt.logs[i];
+      const network = testnet ? 'baseSepolia' : 'base';
+      const usdcAddress = TOKENS.USDC.addresses[network].toLowerCase();
 
-          // Check if this is a USDC log
-          const logAddressLower = log.address?.toLowerCase();
-          const isUsdcLog = logAddressLower === usdcAddress;
+      // Collect all USDC transfers
+      const usdcTransfers: Array<{
+        from: string;
+        to: string;
+        value: bigint;
+        formattedAmount: string;
+      }> = [];
 
-          if (isUsdcLog) {
-            try {
-              const decoded = decodeEventLog({
-                abi: ERC20_TRANSFER_ABI,
-                data: log.data,
-                topics: log.topics,
-              });
+      for (const log of txReceipt.logs) {
+        // Check if this is a USDC log
+        const logAddressLower = log?.address?.toLowerCase();
+        const isUsdcLog = logAddressLower === usdcAddress;
 
-              if (decoded.eventName === 'Transfer' && decoded.args) {
-                const args = decoded.args as { from: string; to: string; value: bigint };
+        if (isUsdcLog) {
+          try {
+            const decoded = decodeEventLog({
+              abi: ERC20_TRANSFER_ABI,
+              data: log.data,
+              topics: log.topics,
+            });
 
-                if (args.value && args.to && args.from) {
-                  const formattedAmount = formatUnits(args.value, 6);
+            if (decoded.eventName === 'Transfer' && decoded.args) {
+              const args = decoded.args as { from: string; to: string; value: bigint };
 
-                  usdcTransfers.push({
-                    from: args.from,
-                    to: args.to,
-                    value: args.value,
-                    formattedAmount,
-                    logIndex: i,
-                  });
-                }
+              if (typeof args.value === 'bigint' && args.to && args.from) {
+                usdcTransfers.push({
+                  from: args.from,
+                  to: args.to,
+                  value: args.value,
+                  formattedAmount: formatUnits(args.value, TOKENS.USDC.decimals),
+                });
               }
-            } catch (_e) {
-              // Do not fail here - fail when we can't find a single valid transfer
             }
+          } catch (_e) {
+            // Do not fail here - fail when we can't find a single valid transfer
           }
         }
+      }
 
-        // Now select the correct transfer
-        // Strategy: Find the transfer from the sender (smart wallet) address
-        if (usdcTransfers.length > 0 && senderAddress) {
-          // Look for transfers from the sender address (smart wallet)
-          // Compare checksummed addresses for consistency
-          const senderTransfers = usdcTransfers.filter((t) => {
-            try {
-              return isAddressEqual(t.from as Address, senderAddress!);
-            } catch {
-              return false;
-            }
-          });
-
-          if (senderTransfers.length === 0) {
-            // No transfer from the sender wallet was found
-            throw new Error(
-              `Unable to find USDC transfer from sender wallet ${receipt.result.sender}. ` +
-                `Found ${usdcTransfers.length} USDC transfer(s) but none originated from the sender wallet.`
-            );
-          }
-          if (senderTransfers.length > 1) {
-            // Multiple transfers from the sender wallet found
-            const transferDetails = senderTransfers
-              .map((t) => `${t.formattedAmount} USDC to ${t.to}`)
-              .join(', ');
-            throw new Error(
-              `Found multiple USDC transfers from sender wallet ${receipt.result.sender}: ${transferDetails}. Expected exactly one transfer.`
-            );
-          }
-          // Exactly one transfer from sender found
-          amount = senderTransfers[0].formattedAmount;
-          recipient = senderTransfers[0].to;
+      // Find the payment transfer from the sender (smart wallet) address.
+      const senderTransfers = usdcTransfers.filter((transfer) => {
+        try {
+          return isAddressEqual(transfer.from as Address, senderAddress);
+        } catch {
+          return false;
         }
+      });
+
+      if (senderTransfers.length === 0) {
+        throw new Error(
+          `Unable to find USDC transfer from sender wallet ${receipt.result.sender}. ` +
+            `Found ${usdcTransfers.length} USDC transfer(s) but none originated from the sender wallet.`
+        );
+      }
+      if (senderTransfers.length > 1) {
+        const transferDetails = senderTransfers
+          .map((transfer) => `${transfer.formattedAmount} USDC to ${transfer.to}`)
+          .join(', ');
+        throw new Error(
+          `Found multiple USDC transfers from sender wallet ${receipt.result.sender}: ${transferDetails}. Expected exactly one transfer.`
+        );
+      }
+
+      const [paymentTransfer] = senderTransfers;
+      if (paymentTransfer.value <= 0n) {
+        throw new Error(
+          'Unable to verify payment: USDC transfer amount must be greater than zero.'
+        );
       }
 
       if (telemetry) {
@@ -245,8 +242,8 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
         id: id as Hex,
         message: 'Payment completed successfully',
         sender: receipt.result.sender,
-        amount,
-        recipient,
+        amount: paymentTransfer.formattedAmount,
+        recipient: paymentTransfer.to,
       };
       return result;
     }

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
@@ -58,7 +58,12 @@ function getRpcErrorMessage(response: unknown): string | undefined {
 }
 
 async function readJsonRpcResponse(response: Response): Promise<JsonRpcResponse> {
-  if (response.ok === false) {
+  const hasHttpError =
+    response.ok === false ||
+    (typeof response.ok !== 'boolean' &&
+      typeof response.status === 'number' &&
+      (response.status < 200 || response.status >= 300));
+  if (hasHttpError) {
     throw new Error(`RPC request failed with HTTP status ${response.status}`);
   }
 

--- a/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
+++ b/packages/account-sdk/src/interface/payment/getPaymentStatus.ts
@@ -13,6 +13,7 @@ import {
   TOKENS,
 } from './constants.js';
 import type { PaymentStatus, PaymentStatusOptions } from './types.js';
+import { validateStringAmount } from './utils/validation.js';
 
 function getDefaultBundlerUrl(testnet: boolean): string {
   return testnet ? DEFAULT_BUNDLER_URLS.baseSepolia : DEFAULT_BUNDLER_URLS.base;
@@ -23,6 +24,28 @@ function getBundlerRequestHeaders(usingDefaultBundlerUrl: boolean): Record<strin
     'Content-Type': 'application/json',
     ...(usingDefaultBundlerUrl ? DEFAULT_BUNDLER_HEADERS : {}),
   };
+}
+
+function getRpcErrorMessage(response: unknown): string | undefined {
+  if (!response || typeof response !== 'object' || !('error' in response)) {
+    return undefined;
+  }
+
+  const rpcError = (response as { error?: unknown }).error;
+  if (rpcError === undefined || rpcError === null) {
+    return undefined;
+  }
+
+  if (
+    typeof rpcError === 'object' &&
+    'message' in rpcError &&
+    typeof rpcError.message === 'string' &&
+    rpcError.message
+  ) {
+    return rpcError.message;
+  }
+
+  return 'Network error';
 }
 
 /**
@@ -50,15 +73,19 @@ function getBundlerRequestHeaders(usingDefaultBundlerUrl: boolean): Record<strin
  *     testnet: true
  *   })
  *
- *   // With custom bundler URL to avoid rate limits
- *   const status = await getPaymentStatus({
+ *   // With a trusted custom bundler URL to avoid rate limits
+ *   const customStatus = await getPaymentStatus({
  *     id: "0x1234...5678",
+ *     expectedPayment: {
+ *       amount: "10.50",
+ *       recipient: "0xFe21034794A5a574B94fE4fDfD16e005F1C96e51"
+ *     },
  *     testnet: false,
  *     bundlerUrl: 'https://my-bundler.example.com/rpc'
  *   })
  *
  *   if (status.status === 'failed') {
- *     console.log(`Payment failed: ${status.reason}`)
+ *     console.info(`Payment failed: ${status.reason}`)
  *   }
  * } catch (error) {
  *   console.error('Unable to check payment status:', error.message)
@@ -95,15 +122,9 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
       }),
     }).then((res) => res.json());
 
-    // Handle RPC errors
-    if (receipt.error) {
-      console.error('[getPaymentStatus] RPC error:', receipt.error);
-      const errorMessage = receipt.error.message || 'Network error';
-      if (telemetry) {
-        logPaymentStatusCheckError({ testnet, correlationId, errorMessage });
-      }
-      // Re-throw error for RPC failures
-      throw new Error(`RPC error: ${errorMessage}`);
+    const receiptErrorMessage = getRpcErrorMessage(receipt);
+    if (receiptErrorMessage) {
+      throw new Error(`RPC error: ${receiptErrorMessage}`);
     }
 
     // If no result, payment is still pending or not found
@@ -119,6 +140,11 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
           params: [id],
         }),
       }).then((res) => res.json());
+
+      const userOpErrorMessage = getRpcErrorMessage(userOpResponse);
+      if (userOpErrorMessage) {
+        throw new Error(`RPC error: ${userOpErrorMessage}`);
+      }
 
       if (userOpResponse.result) {
         // UserOp exists but no receipt yet - it's pending
@@ -146,22 +172,34 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
       return result;
     }
 
-    // Parse the receipt
-    const { success, receipt: txReceipt, reason } = receipt.result;
+    const userOpReceipt = receipt.result;
+    if (
+      typeof id !== 'string' ||
+      typeof userOpReceipt.userOpHash !== 'string' ||
+      userOpReceipt.userOpHash.toLowerCase() !== id.toLowerCase()
+    ) {
+      throw new Error(
+        'Unable to verify payment: receipt does not match the requested transaction.'
+      );
+    }
+
+    const { success, reason } = userOpReceipt;
 
     // Determine status based on success flag
     if (success === true) {
-      if (!Array.isArray(txReceipt?.logs)) {
-        throw new Error('Unable to verify payment: transaction receipt is missing logs.');
+      // ERC-7769 top-level logs are scoped to this UserOperation. Transaction receipt logs include
+      // every UserOperation in the bundle and must not be used for payment verification.
+      if (!Array.isArray(userOpReceipt.logs)) {
+        throw new Error('Unable to verify payment: user operation receipt is missing logs.');
       }
 
-      if (typeof receipt.result.sender !== 'string') {
+      if (typeof userOpReceipt.sender !== 'string') {
         throw new Error('Unable to verify payment: receipt is missing a valid sender address.');
       }
 
       let senderAddress: Address;
       try {
-        senderAddress = getAddress(receipt.result.sender);
+        senderAddress = getAddress(userOpReceipt.sender);
       } catch {
         throw new Error('Unable to verify payment: receipt is missing a valid sender address.');
       }
@@ -177,7 +215,7 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
         formattedAmount: string;
       }> = [];
 
-      for (const log of txReceipt.logs) {
+      for (const log of userOpReceipt.logs) {
         // Check if this is a USDC log
         const logAddressLower = log?.address?.toLowerCase();
         const isUsdcLog = logAddressLower === usdcAddress;
@@ -219,7 +257,7 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
 
       if (senderTransfers.length === 0) {
         throw new Error(
-          `Unable to find USDC transfer from sender wallet ${receipt.result.sender}. ` +
+          `Unable to find USDC transfer from sender wallet ${userOpReceipt.sender}. ` +
             `Found ${usdcTransfers.length} USDC transfer(s) but none originated from the sender wallet.`
         );
       }
@@ -228,7 +266,7 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
           .map((transfer) => `${transfer.formattedAmount} USDC to ${transfer.to}`)
           .join(', ');
         throw new Error(
-          `Found multiple USDC transfers from sender wallet ${receipt.result.sender}: ${transferDetails}. Expected exactly one transfer.`
+          `Found multiple USDC transfers from sender wallet ${userOpReceipt.sender}: ${transferDetails}. Expected exactly one transfer.`
         );
       }
 
@@ -240,6 +278,7 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
       }
 
       if (expectedPayment !== undefined) {
+        // Defend JavaScript callers that do not get the PaymentStatusOptions type checks.
         if (
           !expectedPayment ||
           typeof expectedPayment.amount !== 'string' ||
@@ -250,16 +289,12 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
 
         let expectedAmount: bigint;
         try {
+          validateStringAmount(expectedPayment.amount, TOKENS.USDC.decimals);
           expectedAmount = parseUnits(expectedPayment.amount, TOKENS.USDC.decimals);
         } catch {
           throw new Error('Unable to verify payment: expected USDC amount is invalid.');
         }
 
-        if (expectedAmount <= 0n) {
-          throw new Error(
-            'Unable to verify payment: expected USDC amount must be greater than zero.'
-          );
-        }
         if (paymentTransfer.value !== expectedAmount) {
           throw new Error(
             'Unable to verify payment: USDC amount does not match the expected amount.'
@@ -287,7 +322,7 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
         status: 'completed' as const,
         id: id as Hex,
         message: 'Payment completed successfully',
-        sender: receipt.result.sender,
+        sender: userOpReceipt.sender,
         amount: paymentTransfer.formattedAmount,
         recipient: paymentTransfer.to,
       };
@@ -311,7 +346,7 @@ export async function getPaymentStatus(options: PaymentStatusOptions): Promise<P
       status: 'failed' as const,
       id: id as Hex,
       message: 'Payment failed',
-      sender: receipt.result.sender,
+      sender: userOpReceipt.sender,
       reason: userFriendlyReason,
     };
     return result;

--- a/packages/account-sdk/src/interface/payment/types.ts
+++ b/packages/account-sdk/src/interface/payment/types.ts
@@ -106,9 +106,9 @@ export interface PaymentStatusOptions {
    * Provide values from the merchant's server-side order, not from the payer.
    */
   expectedPayment?: {
-    /** Expected USDC amount as a decimal string (e.g., "10.50") */
+    /** Expected positive USDC amount with at most 6 decimal places (e.g., "10.50") */
     amount: string;
-    /** Expected USDC recipient address */
+    /** Expected USDC recipient address (the `to` address in the server-side order) */
     recipient: Address;
   };
   /** Whether to check on testnet (Base Sepolia). Defaults to false (mainnet) */

--- a/packages/account-sdk/src/interface/payment/types.ts
+++ b/packages/account-sdk/src/interface/payment/types.ts
@@ -101,6 +101,16 @@ export type PaymentResult = PaymentSuccess;
 export interface PaymentStatusOptions {
   /** Transaction ID (userOp hash) to check status for */
   id: string;
+  /**
+   * Optional trusted payment details to verify against the on-chain USDC transfer.
+   * Provide values from the merchant's server-side order, not from the payer.
+   */
+  expectedPayment?: {
+    /** Expected USDC amount as a decimal string (e.g., "10.50") */
+    amount: string;
+    /** Expected USDC recipient address */
+    recipient: Address;
+  };
   /** Whether to check on testnet (Base Sepolia). Defaults to false (mainnet) */
   testnet?: boolean;
   /** Whether to enable telemetry logging. Defaults to true */


### PR DESCRIPTION
## Summary
- validate the returned UserOperation hash and inspect only ERC-7769 logs scoped to that operation, preventing other operations in the same bundle from satisfying payment checks
- require exactly one positive sender-origin USDC transfer and optionally verify it against trusted order amount and recipient values
- validate IDs and expected payment details before networking, and fail closed on missing, malformed, mismatched, or excess-precision evidence
- reject JSON-RPC errors, unsuccessful HTTP responses, malformed payloads, and invalid method-specific result fields with exactly one terminal error event
- preserve typed JSON-RPC and viem address data through verification; document backend verification and one-time payment ID consumption

Security ticket: https://jira.coinbase-corp.com/browse/SECBUGS-14988

## Test plan
- [x] `yarn workspace @base-org/account test --run` (1,044 tests)
- [x] `yarn workspace @base-org/account typecheck`
- [x] `yarn workspace sdk-playground test --run` (39 tests)
- [x] `yarn workspace sdk-playground typecheck`
- [x] `yarn build:packages`
- [x] `yarn workspace sdk-playground build` (passes with pre-existing unrelated export warnings)
- [x] targeted Biome checks for all changed TypeScript/TSX files

Made with [Cursor](https://cursor.com)