### PR TITLE
fix(account-sdk): require factoryData for undeployed smart accounts

### DIFF
--- a/packages/account-sdk/src/sign/base-account/utils/createSmartAccount.test.ts
+++ b/packages/account-sdk/src/sign/base-account/utils/createSmartAccount.test.ts
@@ -7,6 +7,7 @@ import { encodeFunctionData, keccak256 } from 'viem/utils';
 import { beforeEach, describe, expect, vi } from 'vitest';
 
 import { createSmartAccount, sign, wrapSignature } from './createSmartAccount.js';
+import { factoryAddress } from './constants.js';
 
 const privateKey = '0x8d0ec8aa1f67f8c11db3c191d3d66408e148759acd617fa22ab5d5d677a234e9';
 const signer = privateKeyToAccount(privateKey);
@@ -17,6 +18,38 @@ const signerWebauthn = toWebAuthnAccount({
 const client = createClient({
   transport: http(),
   chain: baseSepolia,
+});
+
+describe('getFactoryArgs', () => {
+  it('returns the factory and factoryData when factoryData is provided', async () => {
+    const factoryData = '0x1234';
+    const account = await createSmartAccount({
+      client,
+      owner: signer,
+      ownerIndex: 0,
+      address: '0xBb0c1d5E7f530e8e648150fc7Cf30912575523E8',
+      factoryData,
+    });
+
+    await expect(account.getFactoryArgs()).resolves.toEqual({
+      factory: factoryAddress,
+      factoryData,
+    });
+  });
+
+  it('throws a clear error when factoryData is missing', async () => {
+    const account = await createSmartAccount({
+      client,
+      owner: signer,
+      ownerIndex: 0,
+      address: '0xBb0c1d5E7f530e8e648150fc7Cf30912575523E8',
+      factoryData: undefined,
+    });
+
+    await expect(account.getFactoryArgs()).rejects.toThrow(
+      'factoryData was not provided',
+    );
+  });
 });
 
 describe('encodeCalls', () => {

--- a/packages/account-sdk/src/sign/base-account/utils/createSmartAccount.ts
+++ b/packages/account-sdk/src/sign/base-account/utils/createSmartAccount.ts
@@ -136,8 +136,11 @@ export async function createSmartAccount(
     },
 
     async getFactoryArgs() {
-      if (factoryData) return { factory: factory.address, factoryData };
-      // TODO: support creating factory data
+      if (!factoryData) {
+        throw new BaseError(
+          'Cannot deploy smart account: factoryData was not provided and cannot be derived locally.',
+        );
+      }
       return { factory: factory.address, factoryData };
     },
 


### PR DESCRIPTION
Closes #377.

## What changed

- Make `getFactoryArgs()` throw a clear `BaseError` when `factoryData` is missing.
- Add regression coverage for the provided and missing `factoryData` paths.

## Why

When `factoryData` is undefined, returning `{ factory, factoryData: undefined }` can silently produce no init code for an undeployed account and defer the failure to bundler/EntryPoint simulation. The SDK cannot safely derive Coinbase Smart Account factory data from only a single owner and owner index, so failing early is safer.

## Testing

- `git diff --check`
- `corepack yarn workspace @base-org/account test createSmartAccount` could not run because the local checkout has no Yarn state/install (`Couldn't find the node_modules state file`).
