### PR TITLE
docs(readme): fix provider.request usage in Basic SDK Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ yarn add @base-org/account
 3. Request accounts to initialize a connection to wallet
 
    ```js
-   const addresses = provider.request({
+   const addresses = await provider.request({
      method: 'eth_requestAccounts',
    });
    ```
@@ -210,10 +210,13 @@ yarn add @base-org/account
 4. Make more requests
 
    ```js
-   provider.request('personal_sign', [
-     `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
-     addresses[0],
-   ]);
+   await provider.request({
+     method: 'personal_sign',
+     params: [
+       `0x${Buffer.from('test message', 'utf8').toString('hex')}`,
+       addresses[0],
+     ],
+   });
    ```
 
 5. Handle provider events


### PR DESCRIPTION
## Summary

Two issues in the **Basic SDK Usage** snippets in the README that will not work as written.

## 1. Missing `await` (step 3)

```js
const addresses = provider.request({
  method: 'eth_requestAccounts',
});
```

`request()` returns `Promise<unknown>`, so `addresses` is a Promise, not an array. Step 4 then reads `addresses[0]`, which is `undefined`.

## 2. Wrong call signature (step 4)

```js
provider.request('personal_sign', [ ... ]);
```

The provider interface takes a single `RequestArguments` object, not positional arguments:

```ts
// packages/account-sdk/src/core/provider/interface.ts
export interface RequestArguments {
  readonly method: string;
  readonly params?: readonly unknown[] | object;
}

request(args: RequestArguments): Promise<unknown>;
```

Passing `('personal_sign', [...])` means `args` is the string `'personal_sign'` and `args.method` is `undefined`.

This is also inconsistent with step 3 in the same section, which already uses the object form.

## Fix

Adds the missing `await` and switches step 4 to the object form, matching both the type definition and EIP-1193.
