### PR TITLE
fix(prolink): preserve payload query param

### DIFF
--- a/packages/account-sdk/src/interface/public-utilities/prolink/createProlinkUrl.test.ts
+++ b/packages/account-sdk/src/interface/public-utilities/prolink/createProlinkUrl.test.ts
@@ -50,6 +50,16 @@ describe('createProlinkUrl', () => {
       const result = createProlinkUrl(EXAMPLE_PROLINK, undefined, {});
       expect(result).toBe(`https://base.app/base-pay?p=${EXAMPLE_PROLINK}`);
     });
+
+    it('should not allow additional params to overwrite the prolink payload', () => {
+      const result = createProlinkUrl(EXAMPLE_PROLINK, undefined, {
+        p: 'not-the-prolink',
+        ref: 'promo',
+      });
+      const url = new URL(result);
+      expect(url.searchParams.get('p')).toBe(EXAMPLE_PROLINK);
+      expect(url.searchParams.get('ref')).toBe('promo');
+    });
   });
 
   describe('URL encoding', () => {

--- a/packages/account-sdk/src/interface/public-utilities/prolink/createProlinkUrl.ts
+++ b/packages/account-sdk/src/interface/public-utilities/prolink/createProlinkUrl.ts
@@ -38,10 +38,10 @@ export function createProlinkUrl(
   }
 
   const link = new URL(url);
-  link.searchParams.set('p', prolink);
   Object.entries(additionalQueryParams ?? {}).forEach(([key, value]) => {
     link.searchParams.set(key, value);
   });
+  link.searchParams.set('p', prolink);
 
   return link.toString();
 }


### PR DESCRIPTION
## Summary

Fixes #376.

- Applies additional query params before setting the required `p` payload parameter.
- Ensures `additionalQueryParams.p` cannot overwrite the encoded prolink payload.
- Adds a regression test covering the overwrite case while preserving other additional params.

## Testing

```text
corepack yarn install --immutable
# completed with existing peer dependency warnings

corepack yarn workspace @base-org/account exec vitest run src/interface/public-utilities/prolink/createProlinkUrl.test.ts
# passed, 22 tests

corepack yarn biome check packages/account-sdk/src/interface/public-utilities/prolink/createProlinkUrl.ts packages/account-sdk/src/interface/public-utilities/prolink/createProlinkUrl.test.ts
# passed

git diff --check
# passed
```

Note: `corepack yarn workspace @base-org/account typecheck` currently fails in this clean checkout because `src/ui/Dialog/Dialog.tsx` imports generated `./Dialog-css.js`; this PR only touches the prolink utility and test.