### PR TITLE
fix: validate telemetry preference before initialization

### DIFF
--- a/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.test.ts
+++ b/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.test.ts
@@ -2,13 +2,13 @@ import * as telemetryModule from ':core/telemetry/initCCA.js';
 import { store } from ':store/store.js';
 import * as checkCrossOriginModule from ':util/checkCrossOriginOpenerPolicy.js';
 import * as validatePreferencesModule from ':util/validatePreferences.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Hex } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseAccountProvider } from './BaseAccountProvider.js';
 import {
   CreateProviderOptions,
-  createBaseAccountSDK,
   _resetGlobalInitialization,
+  createBaseAccountSDK,
 } from './createBaseAccountSDK.js';
 import * as getInjectedProviderModule from './getInjectedProvider.js';
 
@@ -300,6 +300,19 @@ describe('createProvider', () => {
       createBaseAccountSDK({ preference }).getProvider();
 
       expect(mockValidatePreferences).toHaveBeenCalledWith(preference);
+    });
+
+    it('should validate preferences before writing config or initializing telemetry', () => {
+      mockValidatePreferences.mockImplementationOnce(() => {
+        throw new Error('Telemetry must be a boolean');
+      });
+
+      expect(() => {
+        createBaseAccountSDK({ preference: { telemetry: 0 as any } }).getProvider();
+      }).toThrow('Telemetry must be a boolean');
+
+      expect(mockStore.config.set).not.toHaveBeenCalled();
+      expect(mockLoadTelemetryScript).not.toHaveBeenCalled();
     });
 
     it('should validate sub-account when toOwnerAccount is provided', () => {

--- a/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
+++ b/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
@@ -88,6 +88,8 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
     paymasterUrls: params.paymasterUrls,
   };
 
+  validatePreferences(options.preference);
+
   //  ====================================================================
   //  If we have a toOwnerAccount function, set it in the non-persisted config
   //  ====================================================================
@@ -120,8 +122,6 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
   if (options.preference.telemetry !== false) {
     initializeTelemetryOnce();
   }
-
-  validatePreferences(options.preference);
 
   //  ====================================================================
   //  Return the provider

--- a/packages/account-sdk/src/util/validatePreferences.test.ts
+++ b/packages/account-sdk/src/util/validatePreferences.test.ts
@@ -93,4 +93,12 @@ describe('validateTelemetry', () => {
     };
     expect(() => validatePreferences(invalidPreference)).toThrow('Telemetry must be a boolean');
   });
+
+  it('should throw an error if telemetry is a falsy non-boolean value', () => {
+    const invalidPreference: Preference = {
+      options: 'all',
+      telemetry: 0 as any,
+    };
+    expect(() => validatePreferences(invalidPreference)).toThrow('Telemetry must be a boolean');
+  });
 });

--- a/packages/account-sdk/src/util/validatePreferences.ts
+++ b/packages/account-sdk/src/util/validatePreferences.ts
@@ -19,7 +19,7 @@ export function validatePreferences(preference?: Preference) {
     }
   }
 
-  if (preference.telemetry) {
+  if (preference.telemetry !== undefined) {
     if (typeof preference.telemetry !== 'boolean') {
       throw new Error(`Telemetry must be a boolean`);
     }


### PR DESCRIPTION
Fixes #383.

## Summary
- validates any defined `preference.telemetry` value by type instead of using a truthiness check
- moves preference validation before store writes and telemetry initialization
- adds regression coverage for falsy non-boolean telemetry values and initialization ordering

## Why
`telemetry: 0` previously skipped `validatePreferences()` because `0` is falsy. The telemetry initialization check uses strict comparison (`telemetry !== false`), so the same value was treated as enabled. Validation also ran after telemetry initialization, which meant invalid preference values could be used before they were rejected.

This keeps the documented values (`true`, `false`, or omitted) working as before while rejecting invalid types before side effects.

## Note
I saw #303 also touches configuration validation order. This PR keeps the scope narrow to the telemetry preference type check and the side-effect ordering needed for that validation to be effective.

## Testing
- `corepack yarn workspace @base-org/account node compile-assets.cjs`
- `corepack yarn workspace @base-org/account test src/util/validatePreferences.test.ts src/interface/builder/core/createBaseAccountSDK.test.ts --run`
- `corepack yarn workspace @base-org/account typecheck`
- `corepack yarn biome check packages/account-sdk/src/util/validatePreferences.ts packages/account-sdk/src/util/validatePreferences.test.ts packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.test.ts`