### PR TITLE
fix(account-sdk): validate telemetry preference before init

### DIFF
--- a/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
+++ b/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
@@ -113,6 +113,8 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
   //  One-time initialization and validation
   //  ====================================================================
 
+  validatePreferences(options.preference);
+
   initializeGlobalOnce();
 
   // Telemetry is initialized separately so it can be enabled by later SDK instances
@@ -120,8 +122,6 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
   if (options.preference.telemetry !== false) {
     initializeTelemetryOnce();
   }
-
-  validatePreferences(options.preference);
 
   //  ====================================================================
   //  Return the provider

--- a/packages/account-sdk/src/util/validatePreferences.test.ts
+++ b/packages/account-sdk/src/util/validatePreferences.test.ts
@@ -93,4 +93,12 @@ describe('validateTelemetry', () => {
     };
     expect(() => validatePreferences(invalidPreference)).toThrow('Telemetry must be a boolean');
   });
+
+  it('should throw an error if telemetry is a falsy non-boolean value', () => {
+    const invalidPreference: Preference = {
+      options: 'all',
+      telemetry: 0 as any,
+    };
+    expect(() => validatePreferences(invalidPreference)).toThrow('Telemetry must be a boolean');
+  });
 });

--- a/packages/account-sdk/src/util/validatePreferences.ts
+++ b/packages/account-sdk/src/util/validatePreferences.ts
@@ -19,10 +19,8 @@ export function validatePreferences(preference?: Preference) {
     }
   }
 
-  if (preference.telemetry) {
-    if (typeof preference.telemetry !== 'boolean') {
-      throw new Error(`Telemetry must be a boolean`);
-    }
+  if (preference.telemetry !== undefined && typeof preference.telemetry !== 'boolean') {
+    throw new Error(`Telemetry must be a boolean`);
   }
 }
 


### PR DESCRIPTION
## Summary
- reject defined non-boolean telemetry preferences even when the value is falsy
- validate preferences before one-time telemetry initialization can act on invalid input
- add regression coverage for `telemetry: 0`

Fixes #383.

## Testing
- `corepack yarn workspace @base-org/account exec vitest run src/util/validatePreferences.test.ts src/interface/builder/core/createBaseAccountSDK.test.ts`
- `corepack yarn biome check packages/account-sdk/src/util/validatePreferences.ts packages/account-sdk/src/util/validatePreferences.test.ts packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts`
- `git diff --check`

Note: `corepack yarn workspace @base-org/account typecheck` still fails on this checkout with the existing generated asset error: `src/ui/Dialog/Dialog.tsx(10,17): Cannot find module './Dialog-css.js'`.