### PR TITLE
fix: validate telemetry preference before initialization

### DIFF
--- a/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
+++ b/packages/account-sdk/src/interface/builder/core/createBaseAccountSDK.ts
@@ -110,7 +110,13 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
   store.config.set(options);
 
   //  ====================================================================
-  //  One-time initialization and validation
+  //  Validate preferences before any initialization can use them
+  //  ====================================================================
+
+  validatePreferences(options.preference);
+
+  //  ====================================================================
+  //  One-time initialization
   //  ====================================================================
 
   initializeGlobalOnce();
@@ -120,8 +126,6 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
   if (options.preference.telemetry !== false) {
     initializeTelemetryOnce();
   }
-
-  validatePreferences(options.preference);
 
   //  ====================================================================
   //  Return the provider
@@ -137,6 +141,7 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
 
       return provider;
     },
+
     subAccount: {
       async create(accountParam: AddSubAccountAccount): Promise<SubAccount> {
         return (await sdk.getProvider()?.request({
@@ -149,6 +154,7 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
           ],
         })) as SubAccount;
       },
+
       async get(): Promise<SubAccount | null> {
         const subAccount = store.subAccounts.get();
 
@@ -167,12 +173,14 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
         })) as WalletConnectResponse;
 
         const subAccounts = response.accounts[0].capabilities?.subAccounts;
+
         if (!Array.isArray(subAccounts)) {
           return null;
         }
 
         return subAccounts[0] as SubAccount;
       },
+
       addOwner: async ({
         address,
         publicKey,
@@ -184,12 +192,18 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
       }) => {
         const subAccount = store.subAccounts.get();
         const account = store.account.get();
+
         assertPresence(account, new Error('account does not exist'));
         assertPresence(subAccount?.address, new Error('subaccount does not exist'));
 
         const calls = [];
+
         if (publicKey) {
-          const [x, y] = decodeAbiParameters([{ type: 'bytes32' }, { type: 'bytes32' }], publicKey);
+          const [x, y] = decodeAbiParameters(
+            [{ type: 'bytes32' }, { type: 'bytes32' }],
+            publicKey,
+          );
+
           calls.push({
             to: subAccount.address,
             data: encodeFunctionData({
@@ -225,8 +239,10 @@ export function createBaseAccountSDK(params: CreateProviderOptions) {
           ],
         })) as string;
       },
+
       setToOwnerAccount(toSubAccountOwner: ToOwnerAccountFn): void {
         validateSubAccount(toSubAccountOwner);
+
         store.subAccountsConfig.set({
           toOwnerAccount: toSubAccountOwner,
         });

--- a/packages/account-sdk/src/util/validatePreferences.test.ts
+++ b/packages/account-sdk/src/util/validatePreferences.test.ts
@@ -1,6 +1,9 @@
 import { ToOwnerAccountFn } from ':store/store.js';
 import { Preference } from '../core/provider/interface.js';
-import { validatePreferences, validateSubAccount } from './validatePreferences.js';
+import {
+  validatePreferences,
+  validateSubAccount,
+} from './validatePreferences.js';
 
 describe('validatePreferences', () => {
   it('should not throw an error if preference is undefined', () => {
@@ -14,6 +17,7 @@ describe('validatePreferences', () => {
         auto: true,
       },
     };
+
     expect(() => validatePreferences(validPreference)).not.toThrow();
   });
 
@@ -21,6 +25,7 @@ describe('validatePreferences', () => {
     const validPreference: Preference = {
       options: 'all',
     };
+
     expect(() => validatePreferences(validPreference)).not.toThrow();
   });
 
@@ -33,8 +38,9 @@ describe('validatePreferences', () => {
         dataSuffix: 'suffix',
       },
     };
+
     expect(() => validatePreferences(invalidPreference)).toThrow(
-      'Attribution cannot contain both auto and dataSuffix properties'
+      'Attribution cannot contain both auto and dataSuffix properties',
     );
   });
 
@@ -45,6 +51,7 @@ describe('validatePreferences', () => {
         auto: true,
       },
     };
+
     expect(() => validatePreferences(validPreference)).not.toThrow();
   });
 
@@ -55,17 +62,22 @@ describe('validatePreferences', () => {
         dataSuffix: '0xsuffix',
       },
     };
+
     expect(() => validatePreferences(validPreference)).not.toThrow();
   });
 });
 
 describe('validateSubAccount', () => {
   it('should throw an error if toSubAccountSigner is not a function', () => {
-    expect(() => validateSubAccount(undefined as any)).toThrow('toAccount is not a function');
+    expect(() => validateSubAccount(undefined as any)).toThrow(
+      'toAccount is not a function',
+    );
   });
 
   it('should not throw an error if toSubAccountSigner is a function', () => {
-    const toSubAccountSigner: ToOwnerAccountFn = () => Promise.resolve({} as any);
+    const toSubAccountSigner: ToOwnerAccountFn = () =>
+      Promise.resolve({} as any);
+
     expect(() => validateSubAccount(toSubAccountSigner)).not.toThrow();
   });
 });
@@ -76,6 +88,16 @@ describe('validateTelemetry', () => {
       options: 'all',
       telemetry: true,
     };
+
+    expect(() => validatePreferences(validPreference)).not.toThrow();
+  });
+
+  it('should not throw an error if telemetry is false', () => {
+    const validPreference: Preference = {
+      options: 'all',
+      telemetry: false,
+    };
+
     expect(() => validatePreferences(validPreference)).not.toThrow();
   });
 
@@ -83,6 +105,7 @@ describe('validateTelemetry', () => {
     const validPreference: Preference = {
       options: 'all',
     };
+
     expect(() => validatePreferences(validPreference)).not.toThrow();
   });
 
@@ -91,6 +114,20 @@ describe('validateTelemetry', () => {
       options: 'all',
       telemetry: 'true' as any,
     };
-    expect(() => validatePreferences(invalidPreference)).toThrow('Telemetry must be a boolean');
+
+    expect(() => validatePreferences(invalidPreference)).toThrow(
+      'Telemetry must be a boolean',
+    );
+  });
+
+  it('should throw an error if telemetry is a falsy non-boolean value', () => {
+    const invalidPreference: Preference = {
+      options: 'all',
+      telemetry: 0 as any,
+    };
+
+    expect(() => validatePreferences(invalidPreference)).toThrow(
+      'Telemetry must be a boolean',
+    );
   });
 });

--- a/packages/account-sdk/src/util/validatePreferences.ts
+++ b/packages/account-sdk/src/util/validatePreferences.ts
@@ -19,11 +19,11 @@ export function validatePreferences(preference?: Preference) {
     }
   }
 
-  if (preference.telemetry) {
-    if (typeof preference.telemetry !== 'boolean') {
-      throw new Error(`Telemetry must be a boolean`);
-    }
+  if (preference.telemetry !== undefined) {
+  if (typeof preference.telemetry !== 'boolean') {
+    throw new Error(`Telemetry must be a boolean`);
   }
+}
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes telemetry preference validation so invalid values are rejected before SDK initialization and telemetry setup.

## Changes

- Validate `preference.telemetry` whenever it is explicitly provided.
- Reject non-boolean telemetry values, including falsy values.
- Run preference validation before global initialization and telemetry initialization.
- Add tests covering valid, invalid, undefined, and falsy non-boolean telemetry values.

## Why

Previously, telemetry validation relied on a truthiness check, which allowed falsy non-boolean values to bypass validation.

Additionally, SDK initialization could run before preferences were validated, allowing telemetry-related initialization to occur before an invalid preference was rejected.

## Testing

- `validatePreferences.test.ts`
- `createBaseAccountSDK.test.ts`
- 38 tests passed across the relevant test suites.
- `git diff --check` and `git diff --cached --check` passed.

Fixes #383
