### PR TITLE
fix: reject missing smart account factory data

### DIFF
--- a/packages/account-sdk/src/sign/base-account/utils/createSmartAccount.test.ts
+++ b/packages/account-sdk/src/sign/base-account/utils/createSmartAccount.test.ts
@@ -505,3 +505,19 @@ describe('wrapSignature', () => {
     );
   });
 });
+
+describe('getFactoryArgs', () => {
+  it('throws a clear error when factoryData is missing', async () => {
+    const account = await createSmartAccount({
+      client,
+      owner: signer,
+      ownerIndex: 0,
+      address: '0xBb0c1d5E7f530e8e648150fc7Cf30912575523E8',
+      factoryData: undefined,
+    });
+
+    await expect(account.getFactoryArgs()).rejects.toThrow(
+      'factoryData is required for undeployed smart accounts; provide factoryData when creating the account.'
+    );
+  });
+});

--- a/packages/account-sdk/src/sign/base-account/utils/createSmartAccount.ts
+++ b/packages/account-sdk/src/sign/base-account/utils/createSmartAccount.ts
@@ -137,8 +137,9 @@ export async function createSmartAccount(
 
     async getFactoryArgs() {
       if (factoryData) return { factory: factory.address, factoryData };
-      // TODO: support creating factory data
-      return { factory: factory.address, factoryData };
+      throw new BaseError(
+        'factoryData is required for undeployed smart accounts; provide factoryData when creating the account.'
+      );
     },
 
     async getStubSignature() {


### PR DESCRIPTION
### Summary

Closes #377.

`getFactoryArgs()` now fails early with a clear `BaseError` when an undeployed smart account has no factoryData. This prevents downstream bundler failures caused by an undefined deployment payload.

### How did you test your changes?

- `git diff --check`
- - Added a regression test for the missing-factoryData path.
- - JavaScript dependencies were unavailable in the sandbox, so the focused Vitest run could not execute.