### PR TITLE
docs: document Base Sepolia account readiness limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ const payment = await pay({
 console.log(`Payment successful! ID: ${payment.id}`);
 ```
 
+> [!NOTE]
+> **Base Sepolia and newly created accounts:** `testnet: true` routes Base Pay to Base
+> Sepolia. Newly created Base Accounts may currently connect and sign in but be unable to
+> complete testnet payments because hosted wallet delegation provisioning rejects the request
+> before a Base Pay ID or onchain transaction is created. This is tracked in
+> [#363](https://github.com/base/account-sdk/issues/363). Until resolved, use an account or
+> environment already able to transact on Base Sepolia for integration tests and handle provider
+> rejections explicitly.
+
 ### Check Payment Status
 
 ```typescript

--- a/packages/account-sdk/README.md
+++ b/packages/account-sdk/README.md
@@ -116,6 +116,17 @@
    });
    ```
 
+### Base Sepolia account readiness
+
+> [!NOTE]
+> Newly created Base Accounts may currently connect and report Base Sepolia (84532)
+> capabilities while the hosted wallet rejects transaction or typed-data requests during account
+> provisioning. This is tracked in [#363](https://github.com/base/account-sdk/issues/363). Treat
+> capability discovery as feature support, not proof that the connected account is ready to
+> transact on that chain. Handle provider errors explicitly and use an account or environment
+> known to work on Base Sepolia for integration testing until the hosted-wallet limitation is
+> resolved.
+
 ### Developing locally and running the test dapp
 
 - The Base Account SDK test dapp can be viewed here https://base.github.io/account-sdk/.


### PR DESCRIPTION
### _Summary_

- document the currently reported Base Sepolia limitation for newly created Base Accounts beside the `testnet: true` Base Pay example
- clarify that capability discovery does not guarantee that the connected account has completed hosted-wallet provisioning on that chain
- point developers to #363 and provide non-speculative integration-testing guidance

This is intentionally documentation-only because the rejection occurs in the hosted wallet flow rather than in this SDK repository.

Documents #363 while the underlying hosted-wallet behavior is investigated.

### _How did you test your changes?_

- reviewed both rendered Markdown insertion points
- confirmed the change only modifies `README.md` and `packages/account-sdk/README.md`
- checked the patch for whitespace errors