### PR TITLE
fix(account-cli): enforce CAIP-2 reference length

### DIFF
--- a/packages/account-cli/src/utils/caip.test.ts
+++ b/packages/account-cli/src/utils/caip.test.ts
@@ -37,6 +37,12 @@ describe('CAIP helpers', () => {
       expect(isValidChainId(':8453')).toBe(false);
       expect(isValidChainId('8453')).toBe(false);
     });
+
+    it('enforces the CAIP-2 reference length limit', () => {
+      expect(isValidChainId(`example:${'a'.repeat(32)}`)).toBe(true);
+      expect(isValidChainId(`example:${'a'.repeat(33)}`)).toBe(false);
+      expect(parseChainId(`example:${'a'.repeat(33)}`)).toBeNull();
+    });
   });
 
   describe('resolveChainId', () => {

--- a/packages/account-cli/src/utils/caip.test.ts
+++ b/packages/account-cli/src/utils/caip.test.ts
@@ -39,9 +39,13 @@ describe('CAIP helpers', () => {
     });
 
     it('enforces the CAIP-2 reference length limit', () => {
-      expect(isValidChainId(`example:${'a'.repeat(32)}`)).toBe(true);
-      expect(isValidChainId(`example:${'a'.repeat(33)}`)).toBe(false);
-      expect(parseChainId(`example:${'a'.repeat(33)}`)).toBeNull();
+      const ref32 = 'a'.repeat(32);
+      const ref33 = 'a'.repeat(33);
+
+      expect(isValidChainId(`example:${ref32}`)).toBe(true);
+      expect(parseChainId(`example:${ref32}`)).toEqual({ namespace: 'example', reference: ref32 });
+      expect(isValidChainId(`example:${ref33}`)).toBe(false);
+      expect(parseChainId(`example:${ref33}`)).toBeNull();
     });
   });
 

--- a/packages/account-cli/src/utils/caip.ts
+++ b/packages/account-cli/src/utils/caip.ts
@@ -1,6 +1,6 @@
 import { type ChainAlias, type ChainId, KNOWN_CHAINS, type ParsedChainId } from '../types/caip.js';
 
-const CAIP2_RE = /^[-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,64}$/;
+const CAIP2_RE = /^[-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32}$/;
 
 /** Parse a CAIP-2 chain identifier into namespace and reference. Returns null if invalid. */
 export function parseChainId(chainId: string): ParsedChainId | null {


### PR DESCRIPTION
## Summary
- enforce the CAIP-2 maximum reference length of 32 characters
- add boundary regression coverage for 32- and 33-character references

## Test
npx vitest run packages/account-cli/src/utils/caip.test.ts
12 tests passed.

Fixes #391
